### PR TITLE
Add `saf view:summary`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,6 +4,7 @@
     "oclif-typescript"
   ],
   "rules": {
+    "@typescript-eslint/no-unused-vars": "off",
     "unicorn/filename-case": "off",
     "unicorn/prefer-node-protocol": "off",
     "unicorn/numeric-separators-style": "off",

--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ The MITRE Security Automation Framework (SAF) Command Line Interface (CLI) bring
 
 * [SAF CLI Usage](https://github.com/mitre/saf#usage)
   * Scan - Visit https://saf.mitre.org/#/validate to explore and run inspec profiles
-  * [Generate](https://github.com/mitre/saf#usage) - Set pipeline thresholds
-  * [Validate](https://github.com/mitre/saf#validate) - Verify pipeline thresholds
-  * [View](https://github.com/mitre/saf#view) - Identify overall security status and deep-dive to solve specifc security defects
-  * [Convert](https://github.com/mitre/saf#convert) - Convert security results from all your security tools into a common data format
+  * [Generate](#generate) - Set pipeline thresholds
+  * [Validate](#validate) - Verify pipeline thresholds
+  * [View](#view) - Identify overall security status and deep-dive to solve specifc security defects
+  * [Convert](#convert) - Convert security results from all your security tools into a common data format
   * Harden - Visit https://saf.mitre.org/#/harden to explore and run hardening scripts
 
 
@@ -117,18 +117,39 @@ validate:threshold       Validate the compliance and status counts of an HDF fil
 
 ### View
 
-You can start a local Heimdall Lite instance to visualize your findings with the SAF CLI. To start an instance use the `saf view` command:
+#### Heimdall
+
+You can start a local Heimdall Lite instance to visualize your findings with the SAF CLI. To start an instance use the `saf view:heimdall` command:
 
 ```
-view                     Run an instance of Heimdall Lite to visualize 
+view:heimdall            Run an instance of Heimdall Lite to visualize 
                          your data
 
   OPTIONS
     -p, --port=PORT          Port To Expose Heimdall On (Default 3000)
 
   EXAMPLES
-    saf view -p 8080
+    saf view:heimdall -p 8080
 ```
+
+
+
+#### Summary
+
+To get a quick compliance summary from an HDF file use the `saf view:summary` command:
+
+```
+view:summary            Get a quick compliance overview of an HDF file
+
+	OPTIONS
+		-i, --input=FILE         (required) Input HDF file
+		-j, --json               Output results as JSON
+	
+	EXAMPLES
+		saf view:summary -i rhel7-results.json
+```
+
+ 
 
 ---
 

--- a/src/commands/generate/threshold.ts
+++ b/src/commands/generate/threshold.ts
@@ -39,7 +39,6 @@ export default class GenerateThreshold extends Command {
     for (const [severity, severityTargets] of Object.entries(severityTargetsObject)) {
       const severityStatusCounts = extractStatusCounts(parsedProfile, severity)
       for (const severityTarget of severityTargets) {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const [statusName, _total, thresholdType] = severityTarget.split('.')
         if ((statusName === 'passed' && thresholdType === 'min') || flags.exact) {
           _.set(thresholds, severityTarget, _.get(severityStatusCounts, renameStatusName(statusName)))

--- a/src/commands/validate/threshold.ts
+++ b/src/commands/validate/threshold.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import {Command, flags} from '@oclif/command'
 import flat from 'flat'
 import YAML from 'yaml'

--- a/src/commands/view/heimdall.ts
+++ b/src/commands/view/heimdall.ts
@@ -4,9 +4,9 @@ import fs from 'fs'
 import path from 'path'
 
 export default class Heimdall extends Command {
-  static aliases = ['view']
+  static aliases = ['heimdall']
 
-  static usage = 'view -p, --port=PORT'
+  static usage = 'view:heimdall -p, --port=PORT'
 
   static description = 'Run an instance of Heimdall Lite to visualize your Data'
 

--- a/src/commands/view/summary.ts
+++ b/src/commands/view/summary.ts
@@ -1,0 +1,43 @@
+import {Command, flags} from '@oclif/command'
+import {ContextualizedProfile, convertFileContextual} from 'inspecjs'
+import fs from 'fs'
+import YAML from 'yaml'
+import {calculateCompliance, extractStatusCounts, renameStatusName, severityTargetsObject} from '../../utils/threshold'
+import _ from 'lodash'
+
+export default class Summary extends Command {
+  static aliases = ['summary']
+
+  static usage = 'view -i, --input=FILE -j, --json'
+
+  static description = 'Get a quick compliance overview of an HDF file '
+
+  static flags = {
+    help: flags.help({char: 'h'}),
+    input: flags.string({char: 'i', required: true, description: 'Input HDF file'}),
+    json: flags.boolean({char: 'j', required: false, description: 'Output results as JSON'}),
+  }
+
+  static examples = ['saf view:summary -i rhel7-results.json']
+
+  async run() {
+    const {flags} = this.parse(Summary)
+    const thresholds = {}
+    const parsedExecJSON = convertFileContextual(fs.readFileSync(flags.input, 'utf8'))
+    const parsedProfile = parsedExecJSON.contains[0] as ContextualizedProfile
+    const overallStatusCounts = extractStatusCounts(parsedProfile)
+    const overallCompliance = calculateCompliance(overallStatusCounts)
+
+    flags.json ? _.set(thresholds, 'compliance', overallCompliance) : console.log(`Overall Compliance: ${overallCompliance}%\n`)
+
+    // Severity counts
+    for (const [severity, severityTargets] of Object.entries(severityTargetsObject)) {
+      const severityStatusCounts = extractStatusCounts(parsedProfile, severity)
+      for (const severityTarget of severityTargets) {
+        const [statusName, _severity, thresholdType] = severityTarget.split('.')
+        _.set(thresholds, severityTarget.replace(`.${thresholdType}`, ''), _.get(severityStatusCounts, renameStatusName(statusName)))
+      }
+    }
+    flags.json ? console.log(JSON.stringify(thresholds, null, 2).trim()) : console.log(YAML.stringify(thresholds).trim())
+  }
+}


### PR DESCRIPTION
Adds `saf view:summary`

```
view:summary            Get a quick compliance overview of an HDF file

	OPTIONS
		-i, --input=FILE         (required) Input HDF file
		-j, --json               Output results as JSON
	
	EXAMPLES
		saf view:summary -i rhel7-results.json
```