### PR TITLE
update saf docker install readme instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,13 +100,26 @@ brew upgrade saf-cli
 
 **On Linux and Mac:**
 
+The docker command below can be used to run the SAF CLI one time, where `arguments` contains the command and flags you want to run. For ex: `--version` or `view summary -i hdf-results.json`.
+```
+docker run -it -v$(pwd):/share mitre/saf <arguments>
+```
+
+To run the SAF CLI with a persistent shell for one or more commands, use the following, then run each full command. For ex: `saf --version` or `saf view summary -i hdf-results.json`. You can change the entrypoint you wish to use. For example, run with `--entrypoint sh` to open in a shell terminal. If the specified entrypoint is not found, try using the path such as `--entrypoint /bin/bash`.
+
 ```
 docker run --rm -it --entrypoint bash -v$(pwd):/share mitre/saf
 ```
 
-You can change the entrypoint you wish to use. For example, run with `--entrypoint sh` to open in a shell terminal. If the specified entrypoint is not found, try using the path such as `--entrypoint /bin/bash`.
-
 **On Windows:**
+
+The docker command below can be used to run the SAF CLI one time, where `arguments` contains the command and flags you want to run. For ex: `--version` or `view summary -i hdf-results.json`.
+
+```
+docker run -it -v%cd%:/share mitre/saf <arguments>
+```
+
+To run the SAF CLI with a persistent shell for one or more commands, use the following, then run each full command. For ex: `saf --version` or `saf view summary -i hdf-results.json`. You can change the entrypoint you wish to use. For example, run with `--entrypoint sh` to open in a shell terminal. If the specified entrypoint is not found, try using the path such as `--entrypoint /bin/bash`.
 
 ```
 docker run --rm -it --entrypoint sh -v%cd%:/share mitre/saf

--- a/README.md
+++ b/README.md
@@ -101,15 +101,16 @@ brew upgrade saf-cli
 **On Linux and Mac:**
 
 ```
-docker run -it -v$(pwd):/share mitre/saf
+docker run --rm -it --entrypoint bash -v$(pwd):/share mitre/saf
 ```
+
+You can change the entrypoint you wish to use. For example, run with `--entrypoint sh` to open in a shell terminal. If the specified entrypoint is not found, try using the path such as `--entrypoint /bin/bash`.
 
 **On Windows:**
 
 ```
-docker run -it -v%cd%:/share mitre/saf
+docker run --rm -it --entrypoint sh -v%cd%:/share mitre/saf
 ```
-
 
 
 #### Update via Docker


### PR DESCRIPTION
Problem: 
The previous instructions for installing SAF via docker did not specify an entrypoint, so if someone ran the command, it ran, showed the SAF help results, then stopped and removed the container.

Fix:
Adding specification about the entrypoint so people can run the command and stay in the docker container to run more SAF CLI commands.

The windows command does not appear to work in powershell from minimal testing. This needs clarification.

Signed-off-by: Emily Rodriguez <ecrodriguez@mm279976-pc.lan>