### PR TITLE
Improve Dockerfile to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,10 +20,10 @@ RUN yarn pack --install-if-needed --prod --filename saf.tgz
 FROM node:lts-alpine
 
 COPY --from=builder /build/saf.tgz /build/
-RUN npm install -g /build/saf.tgz
+RUN npm install -g /build/saf.tgz && npm cache clean --force;
 
 # Useful for CI pipelines
-RUN apk add bash jq curl ca-certificates
+RUN apk add --no-cache bash jq curl ca-certificates
 
 ENTRYPOINT ["saf"]
 VOLUME ["/share"]


### PR DESCRIPTION
Hi there,

I've made a small improvement to the Dockerfile that I think could help optimize the image size.

Summary of the changes:
* I added `npm cache clean` after `npm install`. It helps to reduce the size of the image.
* I added `--no-cache` flag to `apk add` to ensure that no useless information is kept inside the Docker image.


Impact on the image size:
* Image size before repair: 603.93 MB
* Image size after repair: 479.92 MB
* Difference: 124.01 MB (20.53%)

I hope that you will find these changes useful to you. Let me know if you have any questions or concerns.

Thanks,