### PR TITLE
Dockerfile fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM node:lts-alpine as builder
+ARG BASE_CONTAINER=node:16-alpine
+
+FROM $BASE_CONTAINER as builder
 
 LABEL name="SAF" \
       vendor="The MITRE Corporation" \
@@ -17,7 +19,7 @@ RUN rm -rf test
 RUN yarn --frozen-lockfile --production --network-timeout 600000
 RUN yarn pack --install-if-needed --prod --filename saf.tgz
 
-FROM node:lts-alpine
+FROM $BASE_CONTAINER as app
 
 COPY --from=builder /build/saf.tgz /build/
 RUN npm install -g /build/saf.tgz && npm cache clean --force;

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_CONTAINER=node:16-alpine
 
-FROM $BASE_CONTAINER as builder
+FROM $BASE_CONTAINER AS builder
 
 LABEL name="SAF" \
       vendor="The MITRE Corporation" \
@@ -19,7 +19,7 @@ RUN rm -rf test
 RUN npm ci --omit=dev --fetch-timeout=600000
 RUN mv "$(npm pack | tail -1)" saf.tgz
 
-FROM $BASE_CONTAINER as app
+FROM $BASE_CONTAINER AS app
 
 COPY --from=builder /build/saf.tgz /build/
 RUN npm install -g /build/saf.tgz && npm cache clean --force;

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,8 @@ RUN mkdir -p /share
 COPY . /build
 WORKDIR /build
 RUN rm -rf test
-RUN yarn --frozen-lockfile --production --network-timeout 600000
-RUN yarn pack --install-if-needed --prod --filename saf.tgz
+RUN npm ci --omit=dev --fetch-timeout=600000
+RUN mv "$(npm pack | tail -1)" saf.tgz
 
 FROM $BASE_CONTAINER as app
 


### PR DESCRIPTION
Uses node16 instead of LTS since we don't currently support LTS (v18).

Gets rid of yarn cli calls.