### PR TITLE
Supplement tags with ts-inspec-objects

### DIFF
--- a/src/commands/supplement/tags/read-obj.ts
+++ b/src/commands/supplement/tags/read-obj.ts
@@ -1,0 +1,38 @@
+import {Command, Flags} from '@oclif/core'
+import {processInSpecProfile, processExecJSON} from '@mitre/inspec-objects'
+import fs from 'fs'
+import {ExecJSON, ProfileJSON} from 'inspecjs'
+import Profile from '@mitre/inspec-objects/lib/objects/profile'
+import Control from '@mitre/inspec-objects/lib/objects/control'
+
+export default class ReadTags extends Command {
+    static usage = 'supplement tags read -i <hdf-or-profile-json> [-o <tag-json>] [-c control-id ...]'
+
+    static description = 'Read the `tags` attribute in a given Heimdall Data Format or InSpec Profile JSON file and send it to stdout or write it to a file'
+
+    static examples = ['saf supplement tags read -i hdf.json -o tag.json', 'saf supplement tags read -i hdf.json -o tag.json -c V-00001 V-00002']
+
+    static flags = {
+      help: Flags.help({char: 'h'}),
+      input: Flags.string({char: 'i', required: true, description: 'An input HDF or profile file'}),
+      output: Flags.string({char: 'o', description: 'An output `tags` JSON file (otherwise the data is sent to stdout)'}),
+      controls: Flags.string({char: 'c', description: 'The id of the control whose tags will be extracted', multiple: true}),
+    }
+
+    async run() {
+      const {flags} = await this.parse(ReadTags)
+
+      const input: ExecJSON.Execution | ProfileJSON.Profile = JSON.parse(fs.readFileSync(flags.input, 'utf8'))
+      const updatedInput = Object.hasOwn((input), 'profiles') ? processExecJSON(input as ExecJSON.Execution) : processInSpecProfile(fs.readFileSync(flags.input, 'utf8'))
+
+      const extractTags = (profile: Profile) => (profile.controls as Control[]).filter(control => flags.controls ? flags.controls.includes(control.id) : true).map(control => control.tags)
+
+      const tags = extractTags(updatedInput)
+
+      if (flags.output) {
+        fs.writeFileSync(flags.output, JSON.stringify(tags, null, 2))
+      } else {
+        process.stdout.write(JSON.stringify(tags, null, 2))
+      }
+    }
+}

--- a/src/commands/supplement/tags/read.ts
+++ b/src/commands/supplement/tags/read.ts
@@ -7,7 +7,7 @@ export default class ReadTags extends Command {
 
     static description = 'Read the `tags` attribute in a given Heimdall Data Format or InSpec Profile JSON file and send it to stdout or write it to a file'
 
-    static examples = ['saf supplement tags read -i hdf.json -o tag.json']
+    static examples = ['saf supplement tags read -i hdf.json -o tag.json', 'saf supplement tags read -i hdf.json -o tag.json -c V-00001 V-00002']
 
     static flags = {
       help: Flags.help({char: 'h'}),
@@ -21,18 +21,11 @@ export default class ReadTags extends Command {
 
       const input: ExecJSON.Execution | ProfileJSON.Profile = JSON.parse(fs.readFileSync(flags.input, 'utf8'))
 
-      const extractTags = (profile: ExecJSON.Profile | ProfileJSON.Profile) => profile.controls.map(control => control.tags)
+      const extractTags = (profile: ExecJSON.Profile | ProfileJSON.Profile) => (profile.controls as Array<ExecJSON.Control | ProfileJSON.Control>).filter(control => flags.controls ? flags.controls.includes(control.id) : true).map(control => control.tags)
 
       const tags = Object.hasOwn(input, 'profiles') ? (input as ExecJSON.Execution).profiles.map(profile => extractTags(profile)) : extractTags(input as ProfileJSON.Profile)
 
-      if (flags.controls) {
-        const filterTags: any[][] = tags.map(tags => tags.filter((tag: { gid: string }) => flags.controls?.includes(tag.gid)))
-        if (flags.output) {
-          fs.writeFileSync(flags.output, JSON.stringify(filterTags, null, 2))
-        } else {
-          process.stdout.write(JSON.stringify(filterTags, null, 2))
-        }
-      } else if (flags.output) {
+      if (flags.output) {
         fs.writeFileSync(flags.output, JSON.stringify(tags, null, 2))
       } else {
         process.stdout.write(JSON.stringify(tags, null, 2))

--- a/src/commands/supplement/tags/read.ts
+++ b/src/commands/supplement/tags/read.ts
@@ -25,7 +25,14 @@ export default class ReadTags extends Command {
 
       const tags = Object.hasOwn(input, 'profiles') ? (input as ExecJSON.Execution).profiles.map(profile => extractTags(profile)) : extractTags(input as ProfileJSON.Profile)
 
-      if (flags.output) {
+      if (flags.controls) {
+        const filterTags: any[][] = tags.map(tags => tags.filter((tag: { gid: string }) => flags.controls?.includes(tag.gid)))
+        if (flags.output) {
+          fs.writeFileSync(flags.output, JSON.stringify(filterTags, null, 2))
+        } else {
+          process.stdout.write(JSON.stringify(filterTags, null, 2))
+        }
+      } else if (flags.output) {
         fs.writeFileSync(flags.output, JSON.stringify(tags, null, 2))
       } else {
         process.stdout.write(JSON.stringify(tags, null, 2))

--- a/src/commands/supplement/tags/read.ts
+++ b/src/commands/supplement/tags/read.ts
@@ -1,0 +1,34 @@
+import {Command, Flags} from '@oclif/core'
+import {ExecJSON, ProfileJSON} from 'inspecjs'
+import fs from 'fs'
+
+export default class ReadTags extends Command {
+    static usage = 'supplement tags read -i <hdf-or-profile-json> [-o <tag-json>] [-c control-id ...]'
+
+    static description = 'Read the `tags` attribute in a given Heimdall Data Format or InSpec Profile JSON file and send it to stdout or write it to a file'
+
+    static examples = ['saf supplement tags read -i hdf.json -o tag.json']
+
+    static flags = {
+      help: Flags.help({char: 'h'}),
+      input: Flags.string({char: 'i', required: true, description: 'An input HDF or profile file'}),
+      output: Flags.string({char: 'o', description: 'An output `tags` JSON file (otherwise the data is sent to stdout)'}),
+      controls: Flags.string({char: 'c', description: 'The id of the control whose tags will be extracted', multiple: true}),
+    }
+
+    async run() {
+      const {flags} = await this.parse(ReadTags)
+
+      const input: ExecJSON.Execution | ProfileJSON.Profile = JSON.parse(fs.readFileSync(flags.input, 'utf8'))
+
+      const extractTags = (profile: ExecJSON.Profile | ProfileJSON.Profile) => profile.controls.map(control => control.tags)
+
+      const tags = Object.hasOwn(input, 'profiles') ? (input as ExecJSON.Execution).profiles.map(profile => extractTags(profile)) : extractTags(input as ProfileJSON.Profile)
+
+      if (flags.output) {
+        fs.writeFileSync(flags.output, JSON.stringify(tags, null, 2))
+      } else {
+        process.stdout.write(JSON.stringify(tags, null, 2))
+      }
+    }
+}

--- a/src/commands/supplement/tags/write.ts
+++ b/src/commands/supplement/tags/write.ts
@@ -51,38 +51,23 @@ export default class WriteTags extends Command {
       const overwriteTags = (profile: ExecJSON.Profile | ProfileJSON.Profile, tags: any) => {
         // Filter our controls
         const filteredControls = (profile.controls as Array<ExecJSON.Control | ProfileJSON.Control>)?.filter(control => flags.controls ?  flags.controls.includes(control.id) : true)
-
         // Check shape
-        console.log(profile.controls.length)
-        console.log(tags.length)
-        if (!flags.controls && profile.controls.length !== tags.length) {
+        if (filteredControls.length !== tags.length) {
           throw new TypeError('Structure of tags data is invalid')
         }
 
         // Overwrite tags
-        const updatedControls = profile.controls.map((control: any, index: number) => {
-          if (filteredControls.includes(control)) {
-            return {
-              ...control,
-              tags: tags[index],
-            }
-          }
-
-          return control
-        })
-        return updatedControls
+        for (const [index, control] of filteredControls.entries()) {
+          control.tags = tags[index]
+        }
       }
 
       if (Object.hasOwn(input, 'profiles')) {
         for (const [i, profile] of (input as ExecJSON.Execution).profiles.entries()) {
-          const updatedControls =  overwriteTags(profile, tags[i])
-
-          profile.controls = updatedControls
+          overwriteTags(profile, tags[i])
         }
       } else {
-        const updatedControls = overwriteTags((input as ProfileJSON.Profile), tags);
-
-        (input as ProfileJSON.Profile).controls = updatedControls
+        overwriteTags((input as ProfileJSON.Profile), tags)
       }
 
       fs.writeFileSync(output, JSON.stringify(input, null, 2))

--- a/src/commands/supplement/tags/write.ts
+++ b/src/commands/supplement/tags/write.ts
@@ -52,7 +52,6 @@ export default class WriteTags extends Command {
         // Filter our controls
         const filteredControls = (profile.controls as Array<ExecJSON.Control | ProfileJSON.Control>)?.filter(control => flags.controls ?  flags.controls.includes(control.id) : true)
         // Check shape
-        console.log()
         if (filteredControls.length !== tags.length) {
           throw new TypeError('Structure of tags data is invalid')
         }

--- a/src/commands/supplement/tags/write.ts
+++ b/src/commands/supplement/tags/write.ts
@@ -51,9 +51,10 @@ export default class WriteTags extends Command {
           throw new TypeError('Structure of tags data is invalid')
         }
 
-        for (const profile of (input as ExecJSON.Execution).profiles) {
+        for (const [i, profile] of (input as ExecJSON.Execution).profiles.entries()) {
+          const currTags = tags[i]
           for (const control of profile.controls) {
-            const matchingTag = tags[0].find((tag: { gid: string }) => tag.gid === control.id)
+            const matchingTag = currTags.find((tag: { gid: string }) => tag.gid === control.id)
             if (matchingTag !== undefined) {
               control.tags = matchingTag
             }
@@ -65,7 +66,7 @@ export default class WriteTags extends Command {
         }
 
         for (const control of (input as ProfileJSON.Profile).controls) {
-          const matchingTag = tags[0].find((tag: { gid: string }) => tag.gid === control.id)
+          const matchingTag = tags.find((tag: { gid: string }) => tag.gid === control.id)
           if (matchingTag !== undefined) {
             control.tags = matchingTag
           }

--- a/src/commands/supplement/tags/write.ts
+++ b/src/commands/supplement/tags/write.ts
@@ -31,7 +31,7 @@ export default class WriteTags extends Command {
 
       const output: string = flags.output || flags.input
 
-      let tags: any
+      let tags: ExecJSON.Control[][] | ProfileJSON.Control[] | string
       if (flags.tagsFile) {
         try {
           tags = JSON.parse(fs.readFileSync(flags.tagsFile, 'utf8'))
@@ -48,10 +48,11 @@ export default class WriteTags extends Command {
         throw new Error('One out of tagsFile or tagsData must be passed')
       }
 
-      const overwriteTags = (profile: ExecJSON.Profile | ProfileJSON.Profile, tags: any) => {
+      const overwriteTags = (profile: ExecJSON.Profile | ProfileJSON.Profile, tags: ExecJSON.Control[] | ProfileJSON.Control[]) => {
         // Filter our controls
         const filteredControls = (profile.controls as Array<ExecJSON.Control | ProfileJSON.Control>)?.filter(control => flags.controls ?  flags.controls.includes(control.id) : true)
         // Check shape
+        console.log()
         if (filteredControls.length !== tags.length) {
           throw new TypeError('Structure of tags data is invalid')
         }
@@ -64,10 +65,10 @@ export default class WriteTags extends Command {
 
       if (Object.hasOwn(input, 'profiles')) {
         for (const [i, profile] of (input as ExecJSON.Execution).profiles.entries()) {
-          overwriteTags(profile, tags[i])
+          overwriteTags(profile, tags[i] as ExecJSON.Control[])
         }
       } else {
-        overwriteTags((input as ProfileJSON.Profile), tags)
+        overwriteTags((input as ProfileJSON.Profile), (tags as ProfileJSON.Control[]))
       }
 
       fs.writeFileSync(output, JSON.stringify(input, null, 2))

--- a/src/commands/supplement/tags/write.ts
+++ b/src/commands/supplement/tags/write.ts
@@ -2,51 +2,63 @@ import {Command, Flags} from '@oclif/core'
 import {ExecJSON} from 'inspecjs'
 import fs from 'fs'
 
-export default class WritePassthrough extends Command {
-    static usage = 'supplement passthrough write -i <input-hdf-json> (-f <input-passthrough-json> | -d <passthrough-json>) [-o <output-hdf-json>]'
+export default class WriteTags extends Command {
+    static usage = 'supplement tags write -i <input-hdf-json> (-f <input-tags-json> | -d <tags-json>) [-o <output-hdf-json>]'
 
-    static summary = 'Overwrite the `passthrough` attribute in a given HDF file with the provided `passthrough` JSON data'
+    static summary = 'Overwrite the `tags` attribute in a given HDF file with the provided `tags` JSON data'
 
-    static description = 'Passthrough data can be any context/structure. See sample ideas at https://github.com/mitre/saf/wiki/Supplement-HDF-files-with-additional-information-(ex.-%60passthrough%60,-%60target%60)'
+    static description = 'Tags data can be any context/structure. See sample ideas at https://github.com/mitre/saf/wiki/Supplement-HDF-files-with-additional-information-(ex.-%60tags%60,-%60target%60)'
 
     static examples = [
-      'saf supplement passthrough write -i hdf.json -d \'{"a": 5}\'',
-      'saf supplement passthrough write -i hdf.json -f passthrough.json -o new-hdf.json',
+      'saf supplement tags write -i hdf.json -d \'{"a": 5}\'',
+      'saf supplement tags write -i hdf.json -f tags.json -o new-hdf.json',
     ]
 
     static flags = {
       help: Flags.help({char: 'h'}),
       input: Flags.string({char: 'i', required: true, description: 'An input Heimdall Data Format file'}),
-      passthroughFile: Flags.string({char: 'f', exclusive: ['passthroughData'], description: 'An input passthrough-data file (can contain any valid JSON); this flag or `passthroughData` must be provided'}),
-      passthroughData: Flags.string({char: 'd', exclusive: ['passthroughFile'], description: 'Input passthrough-data (can be any valid JSON); this flag or `passthroughFile` must be provided'}),
+      tagsFile: Flags.string({char: 'f', exclusive: ['tagsData'], description: 'An input tags-data file (can contain any valid JSON); this flag or `tagsData` must be provided'}),
+      tagsData: Flags.string({char: 'd', exclusive: ['tagsFile'], description: 'Input tags-data (can be any valid JSON); this flag or `tagsFile` must be provided'}),
       output: Flags.string({char: 'o', description: 'An output Heimdall Data Format JSON file (otherwise the input file is overwritten)'}),
     }
 
     async run() {
-      const {flags} = await this.parse(WritePassthrough)
+      const {flags} = await this.parse(WriteTags)
 
-      const input: ExecJSON.Execution & {passthrough?: unknown} = JSON.parse(fs.readFileSync(flags.input, 'utf8'))
+      const input: ExecJSON.Execution & {tags?: unknown} = JSON.parse(fs.readFileSync(flags.input, 'utf8'))
       const output: string = flags.output || flags.input
 
-      let passthrough: unknown
-      if (flags.passthroughFile) {
+      let tags: any
+      if (flags.tagsFile) {
         try {
-          passthrough = JSON.parse(fs.readFileSync(flags.passthroughFile, 'utf8'))
+          tags = JSON.parse(fs.readFileSync(flags.tagsFile, 'utf8'))
         } catch (error: unknown) {
-          throw new Error(`Couldn't parse passthrough data: ${error}`)
+          throw new Error(`Couldn't parse tags data: ${error}`)
         }
-      } else if (flags.passthroughData) {
+      } else if (flags.tagsData) {
         try {
-          passthrough = JSON.parse(flags.passthroughData)
+          tags = JSON.parse(flags.tagsData)
         } catch {
-          passthrough = flags.passthroughData
+          tags = flags.tagsData
         }
       } else {
-        throw new Error('One out of passthroughFile or passthroughData must be passed')
+        throw new Error('One out of tagsFile or tagsData must be passed')
       }
 
-      input.passthrough = passthrough
+      // Check for num of keys and type of objects
+      if (Object.keys(input.profiles[0].controls).length !== Object.keys(tags[0]).length || typeof input.profiles[0].controls !== typeof tags[0]) {
+        throw new TypeError('Structure of tags data is invalid')
+      }
+
+      // Overwrite tags
+      input.profiles[0].controls.forEach(control => {
+        const matchingTag = tags[0].find((tag: { gid: string }) => tag.gid === control.id)
+        if (matchingTag !== undefined) {
+          control.tags = matchingTag
+        }
+      })
 
       fs.writeFileSync(output, JSON.stringify(input, null, 2))
+      console.log('Tags successfully overwritten')
     }
 }

--- a/src/commands/supplement/tags/write.ts
+++ b/src/commands/supplement/tags/write.ts
@@ -1,0 +1,52 @@
+import {Command, Flags} from '@oclif/core'
+import {ExecJSON} from 'inspecjs'
+import fs from 'fs'
+
+export default class WritePassthrough extends Command {
+    static usage = 'supplement passthrough write -i <input-hdf-json> (-f <input-passthrough-json> | -d <passthrough-json>) [-o <output-hdf-json>]'
+
+    static summary = 'Overwrite the `passthrough` attribute in a given HDF file with the provided `passthrough` JSON data'
+
+    static description = 'Passthrough data can be any context/structure. See sample ideas at https://github.com/mitre/saf/wiki/Supplement-HDF-files-with-additional-information-(ex.-%60passthrough%60,-%60target%60)'
+
+    static examples = [
+      'saf supplement passthrough write -i hdf.json -d \'{"a": 5}\'',
+      'saf supplement passthrough write -i hdf.json -f passthrough.json -o new-hdf.json',
+    ]
+
+    static flags = {
+      help: Flags.help({char: 'h'}),
+      input: Flags.string({char: 'i', required: true, description: 'An input Heimdall Data Format file'}),
+      passthroughFile: Flags.string({char: 'f', exclusive: ['passthroughData'], description: 'An input passthrough-data file (can contain any valid JSON); this flag or `passthroughData` must be provided'}),
+      passthroughData: Flags.string({char: 'd', exclusive: ['passthroughFile'], description: 'Input passthrough-data (can be any valid JSON); this flag or `passthroughFile` must be provided'}),
+      output: Flags.string({char: 'o', description: 'An output Heimdall Data Format JSON file (otherwise the input file is overwritten)'}),
+    }
+
+    async run() {
+      const {flags} = await this.parse(WritePassthrough)
+
+      const input: ExecJSON.Execution & {passthrough?: unknown} = JSON.parse(fs.readFileSync(flags.input, 'utf8'))
+      const output: string = flags.output || flags.input
+
+      let passthrough: unknown
+      if (flags.passthroughFile) {
+        try {
+          passthrough = JSON.parse(fs.readFileSync(flags.passthroughFile, 'utf8'))
+        } catch (error: unknown) {
+          throw new Error(`Couldn't parse passthrough data: ${error}`)
+        }
+      } else if (flags.passthroughData) {
+        try {
+          passthrough = JSON.parse(flags.passthroughData)
+        } catch {
+          passthrough = flags.passthroughData
+        }
+      } else {
+        throw new Error('One out of passthroughFile or passthroughData must be passed')
+      }
+
+      input.passthrough = passthrough
+
+      fs.writeFileSync(output, JSON.stringify(input, null, 2))
+    }
+}


### PR DESCRIPTION
This PR is primarily so we can have a record of the supplement tag functions alternatively rewritten with ts-inspec-objects library.

Issues occur in this implementation which are referenced in mitre/ts-inspec-objects#31