### PR TITLE
Move @oclif/test to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "@oclif/plugin-plugins": "^3.3.2",
     "@oclif/plugin-version": "^1",
     "@oclif/plugin-warn-if-update-available": "^2.0.49",
-    "@oclif/test": "^3.0.1",
     "@types/chai": "^4",
     "@types/express": "^4.17.17",
     "@types/flat": "^5.0.2",
@@ -79,6 +78,7 @@
     "eslint-plugin-unicorn": "^48.0.1",
     "mocha": "^10",
     "oclif": "^3",
+    "@oclif/test": "^3.0.1",
     "tmp": "^0.2.1",
     "ts-mocha": "^10.0.0"
   },


### PR DESCRIPTION
[`@oclif/test`](https://socket.dev/npm/package/@oclif/test) is used for testing, not at runtime, so it shouldn't be a dependency.

`@oclif/test` pulls in `sinon`, in which the current version `16.1.1` requires `git` to be installed which is a problem for systems that don't/can't have `git ` installed: https://github.com/sinonjs/sinon/issues/2557
