### PR TITLE
Update macos runner

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build-deploy:
-    runs-on: macos-12
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Macos-12 runner is being deprecated.  Trying out macos-14 to see if it builds using the arm architecture.