### PR TITLE
Properly return a 1 when a threshold is not met

### DIFF
--- a/src/commands/validate/threshold.ts
+++ b/src/commands/validate/threshold.ts
@@ -100,21 +100,13 @@ export default class Threshold extends BaseCommand<typeof Threshold> {
     for (const totalMinimum of totalMin) {
       const [statusName] = totalMinimum.split('.')
       if (_.get(thresholds, totalMinimum) !== undefined) {
-        if (Boolean(
-              _.get(overallStatusCounts, renameStatusName(statusName)) <
-              _.get(thresholds, totalMinimum),
-            )) {
-              //this.exit(1)
-              this.error('local saf cli fail msg', {exit: 1})
-            }
-        
-              // exitNonZeroIfTrue(
-        //   Boolean(
-        //     _.get(overallStatusCounts, renameStatusName(statusName)) <
-        //     _.get(thresholds, totalMinimum),
-        //   ),
-        //   `${totalMinimum}: Threshold not met. Number of received total ${totalMinimum.split('.')[0]} controls (${_.get(overallStatusCounts, renameStatusName(statusName))}) is less than your set threshold for the number of ${totalMinimum.split('.')[0]} controls (${_.get(thresholds, totalMinimum)})`,
-        // )
+        exitNonZeroIfTrue(
+          Boolean(
+            _.get(overallStatusCounts, renameStatusName(statusName)) <
+            _.get(thresholds, totalMinimum),
+          ),
+          `${totalMinimum}: Threshold not met. Number of received total ${totalMinimum.split('.')[0]} controls (${_.get(overallStatusCounts, renameStatusName(statusName))}) is less than your set threshold for the number of ${totalMinimum.split('.')[0]} controls (${_.get(thresholds, totalMinimum)})`,
+        )
       }
     }
 

--- a/src/commands/validate/threshold.ts
+++ b/src/commands/validate/threshold.ts
@@ -100,13 +100,21 @@ export default class Threshold extends BaseCommand<typeof Threshold> {
     for (const totalMinimum of totalMin) {
       const [statusName] = totalMinimum.split('.')
       if (_.get(thresholds, totalMinimum) !== undefined) {
-        exitNonZeroIfTrue(
-          Boolean(
-            _.get(overallStatusCounts, renameStatusName(statusName)) <
-            _.get(thresholds, totalMinimum),
-          ),
-          `${totalMinimum}: Threshold not met. Number of received total ${totalMinimum.split('.')[0]} controls (${_.get(overallStatusCounts, renameStatusName(statusName))}) is less than your set threshold for the number of ${totalMinimum.split('.')[0]} controls (${_.get(thresholds, totalMinimum)})`,
-        )
+        if (Boolean(
+              _.get(overallStatusCounts, renameStatusName(statusName)) <
+              _.get(thresholds, totalMinimum),
+            )) {
+              //this.exit(1)
+              this.error('local saf cli fail msg', {exit: 1})
+            }
+        
+              // exitNonZeroIfTrue(
+        //   Boolean(
+        //     _.get(overallStatusCounts, renameStatusName(statusName)) <
+        //     _.get(thresholds, totalMinimum),
+        //   ),
+        //   `${totalMinimum}: Threshold not met. Number of received total ${totalMinimum.split('.')[0]} controls (${_.get(overallStatusCounts, renameStatusName(statusName))}) is less than your set threshold for the number of ${totalMinimum.split('.')[0]} controls (${_.get(thresholds, totalMinimum)})`,
+        // )
       }
     }
 

--- a/src/utils/oclif/baseCommand.ts
+++ b/src/utils/oclif/baseCommand.ts
@@ -61,7 +61,8 @@ export abstract class BaseCommand<T extends typeof Command> extends Command {
     if (err.message.includes('See more help with --help')) {
       this.warn(err.message.replace('--help', `\x1B[93m${process.argv.at(-2)} ${process.argv.at(-1)} -h or --help\x1B[0m`))
     } else {
-      this.warn(err)
+      throw new Error(err.message, {exit: err.exitCode || 1})
+      // this.error(err, {exit: err.exitCode || 1})
     }
   }
 

--- a/src/utils/oclif/baseCommand.ts
+++ b/src/utils/oclif/baseCommand.ts
@@ -1,4 +1,5 @@
 import {Args, Command, Flags, Interfaces} from '@oclif/core'
+import {CLIError} from '@oclif/core/errors'
 
 export type Flags<T extends typeof Command> = Interfaces.InferredFlags<typeof BaseCommand['baseFlags'] & T['flags']>
 export type Args<T extends typeof Command> = Interfaces.InferredArgs<T['args']>
@@ -61,8 +62,8 @@ export abstract class BaseCommand<T extends typeof Command> extends Command {
     if (err.message.includes('See more help with --help')) {
       this.warn(err.message.replace('--help', `\x1B[93m${process.argv.at(-2)} ${process.argv.at(-1)} -h or --help\x1B[0m`))
     } else {
-      throw new Error(err.message, {exit: err.exitCode || 1})
-      // this.error(err, {exit: err.exitCode || 1})
+      console.error(err.message)
+      process.exit(1)
     }
   }
 

--- a/src/utils/oclif/baseCommand.ts
+++ b/src/utils/oclif/baseCommand.ts
@@ -1,5 +1,4 @@
 import {Args, Command, Flags, Interfaces} from '@oclif/core'
-import {CLIError} from '@oclif/core/errors'
 
 export type Flags<T extends typeof Command> = Interfaces.InferredFlags<typeof BaseCommand['baseFlags'] & T['flags']>
 export type Args<T extends typeof Command> = Interfaces.InferredArgs<T['args']>


### PR DESCRIPTION
SAF CLI should exit with code 1 when a threshold is not met to enable other automation to properly handle its output without having to parse stderr.

Resolves #3298 