### PR TITLE
Remove 'flat' dependency and recreate functionality, pin 'marked' dependency to a version that has cjs, and fix tests

### DIFF
--- a/pack-inspec-objects.bat
+++ b/pack-inspec-objects.bat
@@ -1,0 +1,53 @@
+ECHO OFF
+
+SET original_dir=%cd%
+ECHO %original_dir%
+
+IF DEFINED npm_config_inspec_objects (
+  CD %npm_config_inspec_objects%
+) ELSE (
+  CD ../ts-inspec-objects
+)
+
+IF DEFINED npm_config_branch (
+  CALL git switch %npm_config_branch% || EXIT /B %ERRORLEVEL%
+) ELSE (
+  CALL git switch main || EXIT /B %ERRORLEVEL%
+)
+
+ECHO Executing - git fetch ...
+CALL git fetch || EXIT /B %ERRORLEVEL%
+
+ECHO Executing - git pull ...
+CALL git pull || EXIT /B %ERRORLEVEL%
+
+ECHO Executing - yarn install ...
+CALL npm ci || EXIT /B %ERRORLEVEL%
+
+ECHO Executing - yarn pack ...
+CALL npm pack || EXIT /B %ERRORLEVEL%
+
+ECHO Finished generating the tarball
+
+CD %original_dir%
+
+ECHO Executing - npm install remote ...
+CALL npm i || EXIT /B %ERRORLEVEL%
+
+ECHO Executing - npm install local ...
+
+IF DEFINED npm_config_inspec_objects (
+  FOR /f "tokens=*" %%a IN ('dir /b %npm_config_inspec_objects%\mitre-inspec-objects-*.tgz') DO (
+    SET THIS_TAR_ZIP=%npm_config_inspec_objects%\%%a
+  )
+) ELSE (
+  FOR /f "tokens=*" %%a IN ('dir /b ..\ts-inspec-objects\mitre-inspec-objects-*.tgz') DO (
+    SET THIS_TAR_ZIP=..\ts-inspec-objects\%%a
+  )
+)
+CALL npm i %THIS_TAR_ZIP% || EXIT /B %ERRORLEVEL%
+
+ECHO Executing - npm run prepack ...
+CALL npm run prepack || EXIT /B %ERRORLEVEL%
+
+ECHO Install of local inspecjs complete.

--- a/pack-inspec-objects.sh
+++ b/pack-inspec-objects.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -o errexit   # abort on nonzero exitstatus
+set -o nounset   # abort on unbound variable
+set -o pipefail  # don't hide errors within pipes
+
+ORIGINAL=$PWD
+echo $ORIGINAL
+
+cd "${npm_config_inspec_objects:-../ts-inspec-objects}"
+
+git switch "${npm_config_branch:-main}"
+
+echo "Executing - git fetch ..."
+git fetch
+
+echo "Executing - git pull ..."
+git pull
+
+echo "Executing - npm install ..."
+npm ci
+
+echo "Executing - npm pack ..."
+npm pack
+
+echo "Finished generating the tarball"
+
+cd "$ORIGINAL"
+
+echo "Executing - npm install remote ..."
+npm i
+
+echo "Executing - npm install local ..."
+npm i "${npm_config_inspec_objects:-../ts-inspec-objects}/mitre-inspec-objects-"*".tgz"
+
+echo "Executing - npm run prepack ..."
+npm run prepack
+
+echo "Install of local inspec-objects complete."

--- a/package-lock.json
+++ b/package-lock.json
@@ -102,7 +102,7 @@
         "eslint-plugin-n": "^17.16.2",
         "eslint-plugin-unicorn": "^59.0.0",
         "jsdom": "^26.0.0",
-        "marked": "^16.0.0",
+        "marked": "~15.0.12",
         "mocha": "^11",
         "mock-fs": "^5.2.0",
         "oclif": "^4.8.8",
@@ -11780,15 +11780,16 @@
       "integrity": "sha512-lYrp7FXmBqpmGmsEF92WnSukdgYvLm15FPIODZOx9+3nobkxJxjBYcszqZf5VqTjBtISPSNC7zjU9o3zwpL6AQ=="
     },
     "node_modules/marked": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-16.0.0.tgz",
-      "integrity": "sha512-MUKMXDjsD/eptB7GPzxo4xcnLS6oo7/RHimUMHEDRhUooPwmN9BEpMl7AEOJv3bmso169wHI2wUF9VQgL7zfmA==",
+      "version": "15.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
+      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
       },
       "engines": {
-        "node": ">= 20"
+        "node": ">= 18"
       }
     },
     "node_modules/math-intrinsics": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,6 @@
         "dotenv": "^17.0.1",
         "express": "^5.1.0",
         "fast-xml-parser": "^5.0.7",
-        "flat": "^6.0.1",
         "form-data": "^4.0.0",
         "fs-extra": "^11.1.1",
         "fuse.js": "^7.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@mitre/emass_client": "3.22.0",
         "@mitre/hdf-converters": "2.11.5",
         "@mitre/heimdall-lite": "2.11.5",
-        "@mitre/inspec-objects": "2.0.4",
+        "@mitre/inspec-objects": "2.0.5",
         "@oclif/core": "^4.2.10",
         "@oclif/plugin-help": "^6.0.9",
         "@oclif/plugin-plugins": "^5.0.14",
@@ -3905,11 +3905,11 @@
       }
     },
     "node_modules/@mitre/inspec-objects": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@mitre/inspec-objects/-/inspec-objects-2.0.4.tgz",
-      "integrity": "sha512-IS/VH0orsK0sFPDPmOhlEyPkzkKyDotvr0El/LLPU/seed2jWzTHNEIBVTNtQDisyO+8/IFjMms372XNbax3UQ==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@mitre/inspec-objects/-/inspec-objects-2.0.5.tgz",
+      "integrity": "sha512-U4lCJVSruTb52pzhNmrHT4w7S7/S0tbk3ET+fwW95/PKNW7vbTaUgkwmd+2Qg2LYNqHUUDCjrd1ZZaJ0DKTqqA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@types/flat": "5.0.5",
         "@types/he": "^1.1.2",
         "@types/json-diff": "^1.0.0",
         "@types/jstoxml": "^2.0.2",
@@ -3917,7 +3917,6 @@
         "@types/mustache": "^4.2.0",
         "@types/pretty": "^2.0.1",
         "fast-xml-parser": "^5.0.7",
-        "flat": "6.0.1",
         "he": "^1.2.0",
         "htmlparser2": "^10.0.0",
         "inspecjs": "^2.6.6",
@@ -5214,11 +5213,6 @@
         "@types/range-parser": "*",
         "@types/send": "*"
       }
-    },
-    "node_modules/@types/flat": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@types/flat/-/flat-5.0.5.tgz",
-      "integrity": "sha512-nPLljZQKSnac53KDUDzuzdRfGI0TDb5qPrb+SrQyN3MtdQrOnGsKniHN1iYZsJEBIVQve94Y6gNz22sgISZq+Q=="
     },
     "node_modules/@types/fs-extra": {
       "version": "11.0.4",
@@ -8630,17 +8624,6 @@
       "integrity": "sha512-LNRvR4hr/S8cXXkIY5pTgVP7L3tq6LlYWcg9nWBuW7o1NMxKZo6oOVa/6GIekMGI0Iw7uC+HWimMe9u/VAeKqw==",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/flat": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/flat/-/flat-6.0.1.tgz",
-      "integrity": "sha512-/3FfIa8mbrg3xE7+wAhWeV+bd7L2Mof+xtZb5dRDKZ+wDvYJK4WDYeIOuOhre5Yv5aQObZrlbRmk3RTSiuQBtw==",
-      "bin": {
-        "flat": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/flat-cache": {

--- a/package.json
+++ b/package.json
@@ -222,7 +222,10 @@
     "pack-hdf-converters:darwin:linux": "./pack-hdf-converters.sh",
     "pack-inspecjs": "run-script-os",
     "pack-inspecjs:win32": "pack-inspecjs.bat",
-    "pack-inspecjs:darwin:linux": "./pack-inspecjs.sh"
+    "pack-inspecjs:darwin:linux": "./pack-inspecjs.sh",
+    "pack-inspec-objects": "run-script-os",
+    "pack-inspec-objects:win32": "pack-inspec-objects.bat",
+    "pack-inspec-objects:darwin:linux": "./pack-inspec-objects.sh"
   },
   "types": "lib/index.d.ts",
   "jest": {

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "eslint-plugin-n": "^17.16.2",
     "eslint-plugin-unicorn": "^59.0.0",
     "jsdom": "^26.0.0",
-    "marked": "^16.0.0",
+    "marked": "~15.0.12",
     "mocha": "^11",
     "mock-fs": "^5.2.0",
     "oclif": "^4.8.8",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@mitre/emass_client": "3.22.0",
     "@mitre/hdf-converters": "2.11.5",
     "@mitre/heimdall-lite": "2.11.5",
-    "@mitre/inspec-objects": "2.0.4",
+    "@mitre/inspec-objects": "2.0.5",
     "@oclif/core": "^4.2.10",
     "@oclif/plugin-help": "^6.0.9",
     "@oclif/plugin-plugins": "^5.0.14",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "dotenv": "^17.0.1",
     "express": "^5.1.0",
     "fast-xml-parser": "^5.0.7",
-    "flat": "^6.0.1",
     "form-data": "^4.0.0",
     "fs-extra": "^11.1.1",
     "fuse.js": "^7.0.0",

--- a/src/commands/validate/threshold.ts
+++ b/src/commands/validate/threshold.ts
@@ -21,13 +21,6 @@ import {
 } from '../../utils/threshold'
 import {BaseCommand} from '../../utils/oclif/baseCommand'
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-let flat: any
-
-(async () => { // skipcq: JS-0328
-  flat = await import('flat')
-})()
-
 export default class Threshold extends BaseCommand<typeof Threshold> {
   static readonly usage = '<%= command.id %> -i <hdf-json> [-I <flattened-threshold-json> | -T <template-file>] [-h] [-L info|warn|debug|verbose]'
 
@@ -61,6 +54,7 @@ export default class Threshold extends BaseCommand<typeof Threshold> {
   async run() { // skipcq: JS-R1005
     const {flags} = await this.parse(Threshold)
     let thresholds: ThresholdValues = {}
+    // inline does not seem to support the controls array option
     if (flags.templateInline) {
       // Need to do some processing to convert this into valid JSON
       const flattenedObjects = flags.templateInline.split(',').map((value: string) => value.trim().replace('{', '').replace('}', ''))

--- a/src/commands/validate/threshold.ts
+++ b/src/commands/validate/threshold.ts
@@ -7,7 +7,8 @@ import {expect} from 'chai'
 import {Flags} from '@oclif/core'
 import {ContextualizedProfile, convertFileContextual} from 'inspecjs'
 import {ThresholdValues} from '../../types/threshold'
-import {calculateCompliance,
+import {
+  calculateCompliance,
   exitNonZeroIfTrue,
   extractStatusCounts,
   getControlIdMap,
@@ -15,7 +16,9 @@ import {calculateCompliance,
   severityTargetsObject,
   statusSeverityPaths,
   totalMax,
-  totalMin} from '../../utils/threshold'
+  totalMin,
+  unflattenThreshold
+} from '../../utils/threshold'
 import {BaseCommand} from '../../utils/oclif/baseCommand'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -67,10 +70,10 @@ export default class Threshold extends BaseCommand<typeof Threshold> {
         toUnpack[key] = Number.parseInt(value, 10)
       }
 
-      thresholds = flat.unflatten(toUnpack)
+      thresholds = unflattenThreshold(toUnpack)
     } else if (flags.templateFile) {
       const parsed = YAML.parse(fs.readFileSync(flags.templateFile, 'utf8'))
-      thresholds = Object.values(parsed).every(key => typeof key === 'number') ? flat.unflatten(parsed) : parsed
+      thresholds = Object.values(parsed).every(key => typeof key === 'number') ? unflattenThreshold(parsed) : parsed
     } else {
       console.log('Please provide an inline compliance template or a compliance file.')
       console.log('See https://github.com/mitre/saf/wiki/Validation-with-Thresholds for more information')

--- a/src/commands/validate/threshold.ts
+++ b/src/commands/validate/threshold.ts
@@ -17,7 +17,7 @@ import {
   statusSeverityPaths,
   totalMax,
   totalMin,
-  unflattenThreshold
+  unflattenThreshold,
 } from '../../utils/threshold'
 import {BaseCommand} from '../../utils/oclif/baseCommand'
 

--- a/src/types/threshold.d.ts
+++ b/src/types/threshold.d.ts
@@ -18,38 +18,38 @@ export type ControlIDThresholdValues = Record<string, Record<string, string[]>>
 export type ThresholdValues = {
   compliance?: {min?: number, max?: number}
   passed?: {
-    total: {controls?: string[], min?: number, max?: number}
-    critical: {controls?: string[], min?: number, max?: number}
-    high: {controls?: string[], min?: number, max?: number}
-    medium: {controls?: string[], min?: number, max?: number}
-    low: {controls?: string[], min?: number, max?: number}
+    total?: {controls?: string[], min?: number, max?: number}
+    critical?: {controls?: string[], min?: number, max?: number}
+    high?: {controls?: string[], min?: number, max?: number}
+    medium?: {controls?: string[], min?: number, max?: number}
+    low?: {controls?: string[], min?: number, max?: number}
   }
   failed?: {
-    total: {controls?: string[], min?: number, max?: number}
-    critical: {controls?: string[], min?: number, max?: number}
-    high: {controls?: string[], min?: number, max?: number}
-    medium: {controls?: string[], min?: number, max?: number}
-    low: {controls?: string[], min?: number, max?: number}
+    total?: {controls?: string[], min?: number, max?: number}
+    critical?: {controls?: string[], min?: number, max?: number}
+    high?: {controls?: string[], min?: number, max?: number}
+    medium?: {controls?: string[], min?: number, max?: number}
+    low?: {controls?: string[], min?: number, max?: number}
   }
   skipped?: {
-    total: {controls?: string[], min?: number, max?: number}
-    critical: {controls?: string[], min?: number, max?: number}
-    high: {controls?: string[], min?: number, max?: number}
-    medium: {controls?: string[], min?: number, max?: number}
-    low: {controls?: string[], min?: number, max?: number}
+    total?: {controls?: string[], min?: number, max?: number}
+    critical?: {controls?: string[], min?: number, max?: number}
+    high?: {controls?: string[], min?: number, max?: number}
+    medium?: {controls?: string[], min?: number, max?: number}
+    low?: {controls?: string[], min?: number, max?: number}
   }
   no_impact?: {
-    total: {controls?: string[], min?: number, max?: number}
-    critical: {controls?: string[], min?: number, max?: number}
-    high: {controls?: string[], min?: number, max?: number}
-    medium: {controls?: string[], min?: number, max?: number}
-    low: {controls?: string[], min?: number, max?: number}
+    total?: {controls?: string[], min?: number, max?: number}
+    critical?: {controls?: string[], min?: number, max?: number}
+    high?: {controls?: string[], min?: number, max?: number}
+    medium?: {controls?: string[], min?: number, max?: number}
+    low?: {controls?: string[], min?: number, max?: number}
   }
   error?: {
-    total: {controls?: string[], min?: number, max?: number}
-    critical: {controls?: string[], min?: number, max?: number}
-    high: {controls?: string[], min?: number, max?: number}
-    medium: {controls?: string[], min?: number, max?: number}
-    low: {controls?: string[], min?: number, max?: number}
+    total?: {controls?: string[], min?: number, max?: number}
+    critical?: {controls?: string[], min?: number, max?: number}
+    high?: {controls?: string[], min?: number, max?: number}
+    medium?: {controls?: string[], min?: number, max?: number}
+    low?: {controls?: string[], min?: number, max?: number}
   }
 }

--- a/src/utils/ohdf/calculations.ts
+++ b/src/utils/ohdf/calculations.ts
@@ -1,16 +1,8 @@
-// utils/calculations.ts
-
 import _ from 'lodash'
 import {ContextualizedEvaluation, ContextualizedProfile} from 'inspecjs'
 import {calculateCompliance, extractStatusCounts, renameStatusName, severityTargetsObject} from '../threshold'
 import {createWinstonLogger} from '../logging'
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-let flat: any
-
-(async () => { // skipcq: JS-0328
-  flat = await import('flat')
-})()
+import {flattenThreshold} from '../threshold'
 
 /**
 * The logger for this command.
@@ -69,7 +61,7 @@ export function calculateTotalCountsForSummaries(summaries: Record<string, Recor
   const totals: Record<string, Record<string, number>> = {}
   Object.entries(summaries).forEach(([profileName, profileSummaries]) => {
     profileSummaries.forEach((profileSummary) => {
-      const flattened: Record<string, number> = flat.flatten(profileSummary)
+      const flattened: Record<string, number> = flattenThreshold(profileSummary)
       Object.entries(flattened).forEach(([key, value]) => {
         const existingValue = _.get(totals, `${profileName}.${key}`, 0)
         if (typeof existingValue === 'number') {

--- a/src/utils/ohdf/calculations.ts
+++ b/src/utils/ohdf/calculations.ts
@@ -1,6 +1,6 @@
 import _ from 'lodash'
 import {ContextualizedEvaluation, ContextualizedProfile} from 'inspecjs'
-import {calculateCompliance, extractStatusCounts, flattenThreshold, renameStatusName, severityTargetsObject} from '../threshold'
+import {calculateCompliance, extractStatusCounts, flattenProfileSummary, renameStatusName, severityTargetsObject} from '../threshold'
 import {createWinstonLogger} from '../logging'
 
 /**
@@ -60,7 +60,7 @@ export function calculateTotalCountsForSummaries(summaries: Record<string, Recor
   const totals: Record<string, Record<string, number>> = {}
   Object.entries(summaries).forEach(([profileName, profileSummaries]) => {
     profileSummaries.forEach((profileSummary) => {
-      const flattened: Record<string, number> = flattenThreshold(profileSummary)
+      const flattened: Record<string, number> = flattenProfileSummary(profileSummary)
       Object.entries(flattened).forEach(([key, value]) => {
         const existingValue = _.get(totals, `${profileName}.${key}`, 0)
         if (typeof existingValue === 'number') {

--- a/src/utils/ohdf/calculations.ts
+++ b/src/utils/ohdf/calculations.ts
@@ -1,8 +1,7 @@
 import _ from 'lodash'
 import {ContextualizedEvaluation, ContextualizedProfile} from 'inspecjs'
-import {calculateCompliance, extractStatusCounts, renameStatusName, severityTargetsObject} from '../threshold'
+import {calculateCompliance, extractStatusCounts, flattenThreshold, renameStatusName, severityTargetsObject} from '../threshold'
 import {createWinstonLogger} from '../logging'
-import {flattenThreshold} from '../threshold'
 
 /**
 * The logger for this command.

--- a/src/utils/threshold.ts
+++ b/src/utils/threshold.ts
@@ -396,7 +396,7 @@ export function unflattenThreshold(threshold: Record<string, number>): Threshold
     if (!ret[left]) {
       ret[left] = {}
     }
-    if(right) {
+    if (right) {
       ret[left][middle] = {}
       ret[left][middle][right] = threshold[key]
     } else {

--- a/src/utils/threshold.ts
+++ b/src/utils/threshold.ts
@@ -327,3 +327,103 @@ export function extractControlSummariesBySeverity(profile: ContextualizedProfile
 
   return result
 }
+
+/**
+ * Flattens a threshold file.
+ * {
+ *   passed: { critical: 0, high: 11, medium: 208, low: 8, total: 227 },
+ *   failed: { critical: 0, high: 6, medium: 87, low: 19, total: 112 },
+ *   skipped: { critical: 0, high: 1, medium: 1, low: 1, total: 3 },
+ *   error: { critical: 0, high: 0, medium: 0, low: 0, total: 0 },
+ *   no_impact: { critical: 0, high: 3, medium: 30, low: 0, none: 0, total: 33 }
+ * }
+ * is turned into
+ * {
+ *   'passed.critical': 0,
+ *   'passed.high': 11,
+ *   'passed.medium': 208,
+ *   'passed.low': 8,
+ *   'passed.total': 227,
+ *   'failed.critical': 0,
+ *   'failed.high': 6,
+ *   'failed.medium': 87,
+ *   'failed.low': 19,
+ *   'failed.total': 112,
+ *   'skipped.critical': 0,
+ *   'skipped.high': 1,
+ *   'skipped.medium': 1,
+ *   'skipped.low': 1,
+ *   'skipped.total': 3,
+ *   'error.critical': 0,
+ *   'error.high': 0,
+ *   'error.medium': 0,
+ *   'error.low': 0,
+ *   'error.total': 0,
+ *   'no_impact.critical': 0,
+ *   'no_impact.high': 3,
+ *   'no_impact.medium': 30,
+ *   'no_impact.low': 0,
+ *   'no_impact.none': 0,
+ *   'no_impact.total': 33
+ * }
+ */
+export function flattenThreshold(threshold: Record<string, Record<string, number>>): Record<string, number> {
+  const ret: Record<string, number> = {}
+  for(const status of Object.keys(threshold)) {
+    for(const severity of Object.keys(threshold[status])) {
+      ret[`${status}.${severity}`] = threshold[status][severity]
+    }
+  }
+  return ret
+}
+
+/**
+ * Unflattens a threshold file.
+ * {
+ *   'passed.critical': 0,
+ *   'passed.high': 11,
+ *   'passed.medium': 208,
+ *   'passed.low': 8,
+ *   'passed.total': 227,
+ *   'failed.critical': 0,
+ *   'failed.high': 6,
+ *   'failed.medium': 87,
+ *   'failed.low': 19,
+ *   'failed.total': 112,
+ *   'skipped.critical': 0,
+ *   'skipped.high': 1,
+ *   'skipped.medium': 1,
+ *   'skipped.low': 1,
+ *   'skipped.total': 3,
+ *   'error.critical': 0,
+ *   'error.high': 0,
+ *   'error.medium': 0,
+ *   'error.low': 0,
+ *   'error.total': 0,
+ *   'no_impact.critical': 0,
+ *   'no_impact.high': 3,
+ *   'no_impact.medium': 30,
+ *   'no_impact.low': 0,
+ *   'no_impact.none': 0,
+ *   'no_impact.total': 33
+ * }
+ * is turned into
+ * {
+ *   passed: { critical: 0, high: 11, medium: 208, low: 8, total: 227 },
+ *   failed: { critical: 0, high: 6, medium: 87, low: 19, total: 112 },
+ *   skipped: { critical: 0, high: 1, medium: 1, low: 1, total: 3 },
+ *   error: { critical: 0, high: 0, medium: 0, low: 0, total: 0 },
+ *   no_impact: { critical: 0, high: 3, medium: 30, low: 0, none: 0, total: 33 }
+ * }
+ */
+export function unflattenThreshold(threshold: Record<string, number>): Record<string, Record<string, number>> {
+  const ret: Record<string, Record<string, number>> = {}
+  for(const statusDotSeverity of Object.keys(threshold)) {
+    const [status, severity] = statusDotSeverity.split('.')
+    if(!ret[status]) {
+      ret[status] = {}
+    }
+    ret[status][severity] = threshold[statusDotSeverity];
+  }
+  return ret;
+}

--- a/src/utils/threshold.ts
+++ b/src/utils/threshold.ts
@@ -108,7 +108,7 @@ export function calculateCompliance(statusHash: StatusHash): number {
  * This function does not exit the process, it rather evaluates if an error occurred
  * logs an error message to the console and throws an error with the provided reason.
  *
- * It is the responsibility of the caller to catch the error and exit accordantly.
+ * It is the responsibility of the caller to catch the error and exit accordingly.
  *
  * @param condition - The condition to evaluate. If true, the process will exit with an error.
  * @param reason - Optional. The reason for the error. If not provided, a default message will be used.
@@ -327,7 +327,7 @@ export function extractControlSummariesBySeverity(profile: ContextualizedProfile
 }
 
 /**
- * Flattens a threshold file.
+ * Flattens a profile summary.
  * {
  *   passed: { critical: 0, high: 11, medium: 208, low: 8, total: 227 },
  *   failed: { critical: 0, high: 6, medium: 87, low: 19, total: 112 },
@@ -365,7 +365,7 @@ export function extractControlSummariesBySeverity(profile: ContextualizedProfile
  *   'no_impact.total': 33
  * }
  */
-export function flattenThreshold(threshold: Record<string, Record<string, number>>): Record<string, number> {
+export function flattenProfileSummary(threshold: Record<string, Record<string, number>>): Record<string, number> {
   const ret: Record<string, number> = {}
   for (const status of Object.keys(threshold)) {
     for (const severity of Object.keys(threshold[status])) {

--- a/src/utils/threshold.ts
+++ b/src/utils/threshold.ts
@@ -181,9 +181,7 @@ export function reverseStatusName(statusName: string): 'passed' | 'failed' | 'sk
 }
 
 export function getControlIdMap(profile: ContextualizedProfile, thresholds?: ThresholdValues) {
-  if (!thresholds) {
-    thresholds = {} // skipcq: JS-0083
-  }
+  thresholds ??= {}
 
   for (const c of profile.contains.filter(control => control.extendedBy.length === 0)) {
     const control = c.root

--- a/src/utils/threshold.ts
+++ b/src/utils/threshold.ts
@@ -376,52 +376,32 @@ export function flattenProfileSummary(threshold: Record<string, Record<string, n
 }
 
 /**
- * Unflattens a threshold file.
+ * Unflattens an inline threshold.
  * {
- *   'passed.critical': 0,
- *   'passed.high': 11,
- *   'passed.medium': 208,
- *   'passed.low': 8,
- *   'passed.total': 227,
- *   'failed.critical': 0,
- *   'failed.high': 6,
- *   'failed.medium': 87,
- *   'failed.low': 19,
- *   'failed.total': 112,
- *   'skipped.critical': 0,
- *   'skipped.high': 1,
- *   'skipped.medium': 1,
- *   'skipped.low': 1,
- *   'skipped.total': 3,
- *   'error.critical': 0,
- *   'error.high': 0,
- *   'error.medium': 0,
- *   'error.low': 0,
- *   'error.total': 0,
- *   'no_impact.critical': 0,
- *   'no_impact.high': 3,
- *   'no_impact.medium': 30,
- *   'no_impact.low': 0,
- *   'no_impact.none': 0,
- *   'no_impact.total': 33
+ *   'compliance.min': 66,
+ *   'passed.critical.min': 0,
+ *   'failed.medium.min': 0
  * }
  * is turned into
  * {
- *   passed: { critical: 0, high: 11, medium: 208, low: 8, total: 227 },
- *   failed: { critical: 0, high: 6, medium: 87, low: 19, total: 112 },
- *   skipped: { critical: 0, high: 1, medium: 1, low: 1, total: 3 },
- *   error: { critical: 0, high: 0, medium: 0, low: 0, total: 0 },
- *   no_impact: { critical: 0, high: 3, medium: 30, low: 0, none: 0, total: 33 }
+ *   compliance: { min: 66 },
+ *   passed: { critical: { min: 0 } },
+ *   failed: { medium: { min: 0 } }
  * }
  */
-export function unflattenThreshold(threshold: Record<string, number>): Record<string, Record<string, number>> {
-  const ret: Record<string, Record<string, number>> = {}
-  for (const statusDotSeverity of Object.keys(threshold)) {
-    const [status, severity] = statusDotSeverity.split('.')
-    if (!ret[status]) {
-      ret[status] = {}
+export function unflattenThreshold(threshold: Record<string, number>): ThresholdValues {
+  const ret: Record<string, Record<string, number | Record<string, number>>> = {}
+  for (const key of Object.keys(threshold)) {
+    const [left, middle, right] = key.split('.')
+    if (!ret[left]) {
+      ret[left] = {}
     }
-    ret[status][severity] = threshold[statusDotSeverity]
+    if(right) {
+      ret[left][middle] = {}
+      ret[left][middle][right] = threshold[key]
+    } else {
+      ret[left][middle] = threshold[key]
+    }
   }
   return ret
 }

--- a/src/utils/threshold.ts
+++ b/src/utils/threshold.ts
@@ -369,8 +369,8 @@ export function extractControlSummariesBySeverity(profile: ContextualizedProfile
  */
 export function flattenThreshold(threshold: Record<string, Record<string, number>>): Record<string, number> {
   const ret: Record<string, number> = {}
-  for(const status of Object.keys(threshold)) {
-    for(const severity of Object.keys(threshold[status])) {
+  for (const status of Object.keys(threshold)) {
+    for (const severity of Object.keys(threshold[status])) {
       ret[`${status}.${severity}`] = threshold[status][severity]
     }
   }
@@ -418,12 +418,12 @@ export function flattenThreshold(threshold: Record<string, Record<string, number
  */
 export function unflattenThreshold(threshold: Record<string, number>): Record<string, Record<string, number>> {
   const ret: Record<string, Record<string, number>> = {}
-  for(const statusDotSeverity of Object.keys(threshold)) {
+  for (const statusDotSeverity of Object.keys(threshold)) {
     const [status, severity] = statusDotSeverity.split('.')
-    if(!ret[status]) {
+    if (!ret[status]) {
       ret[status] = {}
     }
-    ret[status][severity] = threshold[statusDotSeverity];
+    ret[status][severity] = threshold[statusDotSeverity]
   }
-  return ret;
+  return ret
 }

--- a/test/commands/validate/threshold.test.ts
+++ b/test/commands/validate/threshold.test.ts
@@ -14,30 +14,33 @@ describe('Test validate threshold - using template file', () => {
   })
 
   it('Validate threshold test - Triple Overlay Invalid Total Counts', async () => {
-    const {stdout} = await runCommand<{name: string}>([
+    const {stdout, stderr} = await runCommand<{name: string}>([
       'validate threshold',
       '-i', path.resolve('./test/sample_data/HDF/input/triple_overlay_profile_example.json'),
       '--templateFile', path.resolve('./test/sample_data/thresholds/triple_overlay_profile_example.json.counts.bad.total.yml'),
     ])
     expect(stdout).to.equal('')
+    expect(stderr).to.equal('Error: failed.total: Threshold not met. Number of received total failed controls (55) is not equal to your set threshold for the number of failed controls (54)\n')
   })
 
   it('Validate threshold test - Triple Overlay Compliance', async () => {
-    const {stdout} = await runCommand<{name: string}>([
+    const {stdout, stderr} = await runCommand<{name: string}>([
       'validate threshold',
       '-i', path.resolve('./test/sample_data/HDF/input/triple_overlay_profile_example.json'),
       '--templateFile', path.resolve('./test/sample_data/thresholds/triple_overlay_profile_example.json.counts.bad.compliance.yml'),
     ])
     expect(stdout).to.equal('')
+    expect(stderr).to.equal('Error: Overall compliance minimum was not satisfied\n')
   })
 
   it('Validate threshold minMaxTotal - Triple Overlay Compliance', async () => {
-    const {stdout} = await runCommand<{name: string}>([
+    const {stdout, stderr} = await runCommand<{name: string}>([
       'validate threshold',
       '-i', path.resolve('./test/sample_data/HDF/input/triple_overlay_profile_example.json'),
       '--templateFile', path.resolve('./test/sample_data/thresholds/triple_overlay_profile_example.json.counts.totalMinMax.yml'),
     ])
     expect(stdout).to.equal('')
+    expect(stderr).to.equal('Error: passed.total.max: Threshold not met. Number of received total passed controls (19) is greater than your set threshold for the number of passed controls (18)\n')
   })
 
   it('Validate threshold test - RHEL-8 Hardened Valid Exact Counts', async () => {
@@ -51,12 +54,13 @@ describe('Test validate threshold - using template file', () => {
   })
 
   it('Validate threshold test - RHEL-8 Hardened Invalid Total Counts', async () => {
-    const {stdout} = await runCommand<{name: string}>([
+    const {stdout, stderr} = await runCommand<{name: string}>([
       'validate threshold',
       '-i', path.resolve('./test/sample_data/HDF/input/rhel-8_hardened.json'),
       '--templateFile', path.resolve('./test/sample_data/thresholds/rhel-8_hardened.counts.bad.noimpactHigh.yml'),
     ])
     expect(stdout).to.equal('')
+    expect(stderr).to.equal('Error: no_impact.high.max: Threshold not met. Number of received total no_impact controls (3) is greater than your set threshold for the number of no_impact controls (2)\n')
   })
 })
 
@@ -77,11 +81,6 @@ describe('Test validate threshold - using inline values', () => {
       '--templateInline', '"{compliance.min: 66}, {passed.critical.min: 0}, {failed.medium.min: 97}"',
     ])
     expect(stdout).to.equal('')
-    // Format stderr to remove newlines, tabs, and extra spaces
-    expect(
-      stderr.replaceAll(/\n/gi, ' ').replaceAll(/\t/gi, ' ').replaceAll(/\s+/g, ' ').trim(),
-    ).to.equal(
-      'Error: failed.medium.min: Threshold not met. Number of received total failed controls (87) is less than your set threshold for the number of failed controls (97)',
-    )
+    expect(stderr).to.equal('Error: failed.medium.min: Threshold not met. Number of received total failed controls (87) is less than your set threshold for the number of failed controls (97)\n')
   })
 })

--- a/test/utils/ohdf/calculations.test.ts
+++ b/test/utils/ohdf/calculations.test.ts
@@ -60,7 +60,7 @@ describe('calculations.ts utils', () => {
   })
 
   it('calculateSeverityCounts modifies the summary correctly', () => {
-    Object.values(execJSONs).forEach(parsedExecJSON => {
+    for(const parsedExecJSON of Object.values(execJSONs)) {
       const summary: Record<string, Record<string, number>> = {}
       const parsedProfile = parsedExecJSON.contains[0] as ContextualizedProfile
 
@@ -72,7 +72,7 @@ describe('calculations.ts utils', () => {
 
       const expectedSummary = loadExpectedData('./test/sample_data/utils/ohdf/calculations/calculateSeverityCounts.sample')
       expect(summary).to.deep.equal(expectedSummary)
-    })
+    }
   })
 
   it('calculateTotalCountsForSummaries calculates the totals correctly', () => {


### PR DESCRIPTION
Removed the 'flat' dependency since that was ESM only and causing problems since our testing frameworks would basically instantly execute and not grant the time it took to do the dynamic import that using it in the real world would allow us to do.  I replaced it with a simplified and handwritten pair of matching flatten and unflatten functions that handle our specific usecase of just threshold files with no options or fanciness.