### PR TITLE
feat: Add --issueStatuses flag to sonarqube2hdf command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1147,6 +1147,7 @@ convert sonarqube2hdf         Pull SonarQube vulnerabilities for the specified
 
   EXAMPLES
     $ saf convert sonarqube2hdf -n sonar_project_key -u http://sonar:9000 --auth abcdefg -p 123 -o scan_results.json -w
+    $ saf convert sonarqube2hdf -n sonar_project_key -u http://sonar:9000 --auth abcdefg -o scan_results.json -s "ACCEPTED,IN_SANDBOX"
 ```
 
 [top](#convert-other-formats-to-hdf)

--- a/README.md
+++ b/README.md
@@ -1123,7 +1123,7 @@ convert sonarqube2hdf         Pull SonarQube vulnerabilities for the specified
                               request ID name from an API and convert into a
                               Heimdall Data Format JSON file
   USAGE
-    $ saf convert sonarqube2hdf -n <sonar-project-key> -u <http://your.sonar.instance:9000> -a <your-sonar-api-key> [ -b <target-branch> | -p <pull-request-id> ] -o <hdf-scan-results-json>
+    $ saf convert sonarqube2hdf -n <sonar-project-key> -u <http://your.sonar.instance:9000> -a <your-sonar-api-key> [ -b <target-branch> | -p <pull-request-id> ] [-s <statuses-to-exclude>] -o <hdf-scan-results-json>
 
   FLAGS
     -a, --auth=<your-sonar-api-key>               (required) SonarQube API Key / User Token - please ensure that the user has permissions for the project (including seeing the code)
@@ -1133,6 +1133,10 @@ convert sonarqube2hdf         Pull SonarQube vulnerabilities for the specified
     -b, --branch=<target-branch>                  Requires Sonarqube Developer Edition or above
     -p, --pullRequestID=<pull-request-id>         Requires Sonarqube Developer Edition or above
     -g, --organization=<value>                    SonarQube organization name - used as a default when necessary to access rule descriptions
+    -s, --excludeIssueStatuses=<value>            Comma-separated list of issue statuses to EXCLUDE from results
+                                                  (e.g. "ACCEPTED,IN_SANDBOX"). Replaces the default exclusions
+                                                  (FALSE_POSITIVE, FIXED for SonarQube 10.4+; CLOSED for older versions).
+                                                  Omit this flag to use defaults.
     -w, --includeRaw                              Include raw input requests in HDF JSON file
 
   GLOBAL FLAGS

--- a/src/commands/convert/sonarqube2hdf.ts
+++ b/src/commands/convert/sonarqube2hdf.ts
@@ -7,7 +7,7 @@ import { BaseCommand } from '../../utils/oclif/base_command';
 export default class Sonarqube2HDF extends BaseCommand<typeof Sonarqube2HDF> {
   static readonly usage
     = '<%= command.id %> -n <sonar-project-key> -u <http://your.sonar.instance:9000> -a <your-sonar-api-key>'
-      + '[ -b <target-branch> | -p <pull-request-id> ] [ -g <organization-name> ] -o <hdf-scan-results-json> [-h] [-w]';
+      + '[ -b <target-branch> | -p <pull-request-id> ] [ -g <organization-name> ] -o <hdf-scan-results-json> [-h] [-w] [-s <statuses-to-exclude>]';
 
   static readonly description
     = 'Pull SonarQube vulnerabilities for the specified project name and optional branch \n'
@@ -58,10 +58,13 @@ export default class Sonarqube2HDF extends BaseCommand<typeof Sonarqube2HDF> {
       required: false,
       description: 'Include raw input requests in HDF JSON file',
     }),
-    issueStatuses: Flags.string({
+    excludeIssueStatuses: Flags.string({
       char: 's',
       required: false,
-      description: 'Comma-separated list of issue statuses to include (e.g. "OPEN,CONFIRMED,ACCEPTED"). Overrides automatic status discovery from the server.',
+      description: 'Comma-separated list of issue statuses to EXCLUDE from results '
+        + '(e.g. "ACCEPTED,IN_SANDBOX"). Replaces the default exclusions '
+        + '(FALSE_POSITIVE, FIXED for SonarQube 10.4+; CLOSED for older versions). '
+        + 'Omit this flag to use defaults.',
     }),
   };
 
@@ -75,7 +78,7 @@ export default class Sonarqube2HDF extends BaseCommand<typeof Sonarqube2HDF> {
       flags.pullRequestID,
       flags.organization,
       flags.includeRaw,
-      flags.issueStatuses,
+      flags.excludeIssueStatuses,
     );
     fs.writeFileSync(
       checkSuffix(flags.output),

--- a/src/commands/convert/sonarqube2hdf.ts
+++ b/src/commands/convert/sonarqube2hdf.ts
@@ -58,6 +58,11 @@ export default class Sonarqube2HDF extends BaseCommand<typeof Sonarqube2HDF> {
       required: false,
       description: 'Include raw input requests in HDF JSON file',
     }),
+    issueStatuses: Flags.string({
+      char: 's',
+      required: false,
+      description: 'Comma-separated list of issue statuses to include (e.g. "OPEN,CONFIRMED,ACCEPTED"). Overrides automatic status discovery from the server.',
+    }),
   };
 
   async run() {
@@ -70,6 +75,7 @@ export default class Sonarqube2HDF extends BaseCommand<typeof Sonarqube2HDF> {
       flags.pullRequestID,
       flags.organization,
       flags.includeRaw,
+      flags.issueStatuses,
     );
     fs.writeFileSync(
       checkSuffix(flags.output),

--- a/src/commands/convert/sonarqube2hdf.ts
+++ b/src/commands/convert/sonarqube2hdf.ts
@@ -13,7 +13,10 @@ export default class Sonarqube2HDF extends BaseCommand<typeof Sonarqube2HDF> {
     = 'Pull SonarQube vulnerabilities for the specified project name and optional branch \n'
       + 'or pull/merge request ID name from an API and convert into a Heimdall Data Format JSON file';
 
-  static readonly examples = ['<%= config.bin %> <%= command.id %> -n sonar_project_key -u http://sonar:9000 --auth abcdefg -p 123 -o scan_results.json -w'];
+  static readonly examples = [
+    '<%= config.bin %> <%= command.id %> -n sonar_project_key -u http://sonar:9000 --auth abcdefg -p 123 -o scan_results.json -w',
+    '<%= config.bin %> <%= command.id %> -n sonar_project_key -u http://sonar:9000 --auth abcdefg -o scan_results.json -s "ACCEPTED,IN_SANDBOX"',
+  ];
 
   static readonly flags = {
     auth: Flags.string({


### PR DESCRIPTION
## Summary

Adds a new `--issueStatuses` (`-s`) flag to the `saf convert sonarqube2hdf`
command. This flag allows users to specify a comma-separated list of issue
statuses to include when pulling issues from the SonarQube API.

## Changes

- Added `issueStatuses` flag (short: `-s`) to the `sonarqube2hdf` command
- The flag value is passed through to the `SonarqubeResults` constructor in
  `@mitre/hdf-converters`

## Usage

    # Use automatic status discovery (default - no flag needed)
    saf convert sonarqube2hdf -n my-project -u https://sonar.example.com -a $TOKEN -o results.json

    # Override with specific statuses
    saf convert sonarqube2hdf -n my-project -u https://sonar.example.com -a $TOKEN -o results.json \
      -s "OPEN,CONFIRMED,ACCEPTED"

    # Include all statuses explicitly
    saf convert sonarqube2hdf -n my-project -u https://sonar.example.com -a $TOKEN -o results.json \
      -s "OPEN,CONFIRMED,FALSE_POSITIVE,ACCEPTED,FIXED"

## Motivation

The upstream `@mitre/hdf-converters` library now supports dynamic issue status
discovery and a user-supplied override (see mitre/heimdall2#7791). This change
exposes that capability through the SAF CLI so operators can control which issue
statuses are retrieved without modifying source code.

## Related

- mitre/heimdall2#7791 - Upstream library change that adds dynamic status
  discovery and the `issueStatuses` constructor parameter