### PR TITLE
Remove the resolve cinc auditor path function

### DIFF
--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -32,6 +32,8 @@ jobs:
         run: |
           Start-Process powershell -Verb RunAs
           . { iwr -useb https://omnitruck.cinc.sh/install.ps1 } | iex; install -project cinc-auditor
+          'C:\cinc-project\cinc-auditor\bin' >> $env:GITHUB_PATH
+          'C:\cinc-project\cinc-auditor\embedded\bin' >> $env:GITHUB_PATH
           $env:Path = $env:Path + ';C:\cinc-project\cinc-auditor\bin' + ';C:\cinc-project\cinc-auditor\embedded\bin'
           cinc-auditor -v
 

--- a/README.md
+++ b/README.md
@@ -1568,34 +1568,33 @@ validate threshold            Validate the compliance and status counts of an HD
 
 #### Delta
 
+Update an existing InSpec profile with new or updated XCCDF guidance. With -M (runMapControls), uses a 3-tier SRG/CCI requirement-first matcher for cross-vendor deltas (e.g. RHEL 9 → Amazon Linux 2023) and persists per-control match decisions into delta.json's links[] field.
+
 See the wiki for more information on 👉 [Delta](https://github.com/mitre/saf/wiki/Delta).
 
 ```
-Update an existing InSpec profile with updated XCCDF guidance
 
 USAGE
-  $ saf generate delta [-h] [-L info|warn|debug|verbose] [-J <value> | --interactive] [-X <value> | -U <value>]
-   [-o <value> | ] [-O <value> | ] [-r <value> | ] [-T rule|group|cis|version | ] [-M -c <value>]
+  $ saf generate delta [-h] [-L info|warn|debug|verbose] [-J <value> | --interactive] [-I <value> | ] [-X <value> |  | -U <value>] [-o <value> | ] [-O <value> | ] [-r <value> | ] [-T rule|group|cis|version | ] [-M -c <value>]
 
 FLAGS
-  -J, --inspecJsonFile=<value>  InSpec Profile Controls JSON summary file
-                                - can be generated using the "[cinc-auditor or inspec] json <profile path> | jq . > profile.json" command
+  -I, --inspecPath=<value>      (required [-J or -I], and also with -M) Absolute or known relative path to the inspec or cinc-auditor executable
+  -J, --inspecJsonFile=<value>  (required [-J or -I]) InSpec Profile Controls JSON summary file - can be generated using the "[cinc-auditor or inspec] json <profile path> | jq . > profile.json" command
   -M, --runMapControls          Run the approximate string matching process
   -O, --ovalXmlFile=<value>     The OVAL XML file containing definitions used in the new guidance - in the form of .xml file
-  -T, --idType=<option>         [default: rule] Control ID Types: 'rule' - Vulnerability IDs (ex. 'SV-XXXXX'), 'group' - Group IDs (ex. 'V-XXXXX'), 'cis' - CIS Rule IDs
-                                (ex. C-1.1.1.1), 'version' - Version IDs (ex. RHEL-07-010020 - also known as STIG IDs)
+  -T, --idType=<option>         [default: rule] Control ID Types: 'rule' - Vulnerability IDs (ex. 'SV-XXXXX'), 'group' - Group IDs (ex. 'V-XXXXX'), 'cis' - CIS Rule IDs (ex. C-1.1.1.1), 'version' - Version IDs (ex.
+                                RHEL-07-010020 - also known as STIG IDs)
                                 <options: rule|group|cis|version>
   -U, --xccdfUrl=<value>        (required [-X or -U] or --interactive) The URL for the XCCDF package containing the new guidance (.zip, e.g., DISA STIG downloads)
   -X, --xccdfXmlFile=<value>    (required [-X or -U] or --interactive) The XCCDF File containing the new guidance (.xml or .zip)
   -c, --controlsDir=<value>     (required with -M or -J not provided) The InSpec profile directory containing the controls to update (controls Delta is processing)
-  -o, --deltaOutputDir=<value>  (required if not --interactive) The output folder for the updated profile (this will contain the new controls modified by delta)
-                                 - if it is not empty, it will be overwritten.
+  -o, --deltaOutputDir=<value>  (required if not --interactive) The output folder for the updated profile (this will contain the new controls modified by delta) - if it is not empty, it will be overwritten.
   -r, --reportFile=<value>      Output markdown report file - must have an extension of .md
 
 GLOBAL FLAGS
-  -h, --help               Show CLI help
   -L, --logLevel=<option>  [default: info] Specify level for logging (if implemented by the CLI command)
                            <options: info|warn|debug|verbose>
+  -h, --help               Show CLI help
       --interactive        Collect input tags interactively (not available on all CLI commands)
 
 EXAMPLES
@@ -1609,49 +1608,50 @@ EXAMPLES
     $ saf generate delta -U <URL-to-benchmark.zip>, -J <profile_summary.json> -c <current-controls-dir> -o <updated_controls_dir>, [options]
 
   Providing a XCCDF (File), a Profile Controls Summary, with Fuzzy matching)
-    $ saf generate delta -X <xccdf_benchmarks.[xml, zip]>, -J <profile_summary.json> -c <current-controls-dir> -o <updated_controls_dir>, -M, [options]
+    $ saf generate delta -X <xccdf_benchmarks.[xml, zip]>, -J <profile_summary.json> -I </path/to/inspec-or-cinc-auditor> -c <current-controls-dir> -o <updated_controls_dir>, -M, [options]
 
   Providing a XCCDF (URL), a Profile Controls Summary, with Fuzzy matching)
-    $ saf generate delta -U <URL-to-benchmark.zip>, -J <profile_summary.json> -c <current-controls-dir> -o <updated_controls_dir>, -M, [options]
+    $ saf generate delta -U <URL-to-benchmark.zip>, -J <profile_summary.json> -I </path/to/inspec-or-cinc-auditor> -c <current-controls-dir> -o <updated_controls_dir>, -M, [options]
 
 ```
 [top](#generate-data-reports-and-more)
 
 #### Delta Supporting Options
-Use this process prior of running `generate delta`. The process updates the controls with metadata provided by the XCCDF guidance to include the controls name and number. Additionally it formates the control the same way the `generate delta` will. Running this process minimizes the delta output content and makes for better and easier visualization of the modification provided by the Delta process.
+Update Profile Control(s) from baseline X to Y based on DISA XCCDF guidance
+
+Use this command prior to running `generate delta`. This command updates the controls in an InSpec profile with the metadata provided by the XCCDF guidance, including the controls' names and numbers. Additionally, it formats the controls in the same way that `generate delta` will generate them. Running this process minimizes the `generate delta` diff, which makes for better and easier visualization of the modifications provided by the `generate delta` command.
 
 ```
 USAGE
-  $ saf generate update_controls4delta [-X <value> | -U <value>] -c <value> [-J <value>] [-P V|SV] [-g] [-f] [-b] [-h] [--interactive] [-L info|warn|debug|verbose]  
+  $ saf generate update_controls4delta -c <value> [-h] [--interactive] [-L info|warn|debug|verbose] [-X <value> | -U <value>] [-J <value>] [-I <value>] [-P V|SV] [-g] [-f] [-b]
 
 FLAGS
+  -I, --inspecPath=<value>      (required [-J or -I]) Absolute or known relative path to the inspec or cinc-auditor executable
+  -J, --inspecJsonFile=<value>  (required [-J or -I]) InSpec Profiles JSON summary file - can be generated using the "[cinc-auditor or inspec] json <profile path> > profile.json" command
+  -P, --controlPrefix=<option>  [default: V] Old control number prefix V or SV, default V
+                                <options: V|SV>
   -U, --xccdfUrl=<value>        (required [-X or -U]) The URL pointing to the XCCDF file containing the new guidance (DISA STIG downloads)
   -X, --xccdfXmlFile=<value>    (required [-X or -U]) The XCCDF XML file containing the new guidance - in the form of .xml file
-  -c, --controlsDir=<value>     (required) The InSpec profile controls directory containing the profiles to be updated  
-  -J, --inspecJsonFile=<value>  Input execution/profile JSON file - can be generated using the "inspec json <profile path> > profile.json"
-                                command. If not provided the `inspec` CLI must be installed
-  -P, --controlPrefix=<option>  [default: V] Old control number prefix V or SV, default V <options: V|SV>
-  -g, --[no-]useXccdfGroupId    Use the XCCDF `Group Id` to rename the controls. Uses prefix V or SV based on controlPrefix option
-                                [default: false]
   -b, --[no-]backupControls     Preserve modified controls in a backup directory (oldControls) inside the controls directory
                                 [default: true]
+  -c, --controlsDir=<value>     (required) The InSpec profile controls directory containing the profiles to be updated
   -f, --[no-]formatControls     Format control contents in the same way `generate delta` will write controls
                                 [default: true]
+  -g, --[no-]useXccdfGroupId    Use the XCCDF `Group Id` to rename the controls. Uses prefix V or SV based on controlPrefix option
+                                [default: false]
 
 GLOBAL FLAGS
-  -h, --help               Show CLI help
   -L, --logLevel=<option>  [default: info] Specify level for logging (if implemented by the CLI command)
-                            <options: info|warn|debug|verbose>
+                           <options: info|warn|debug|verbose>
+  -h, --help               Show CLI help
       --interactive        Collect input tags interactively (not available on all CLI commands)
 
 EXAMPLES
   Providing an XCCDF File
-    $ saf generate update_controls4delta -X ./the_xccdf_guidance_file.xml [-J <profile_json_file.json>]
-      [-c the_controls_directory --no-backupControls --no-formatControls -P <V or SV> -g -L debug]
+    $ saf generate update_controls4delta -X ./the_xccdf_guidance_file.xml [-J <profile_json_file.json> | -I </path/to/inspec-or-cinc-auditor>] [-c the_controls_directory --no-backupControls --no-formatControls -P <V or SV> -g -L debug]
 
   Providing an URL point to an ZIP XCCDF (from DISA STIG downloads)
-    $ saf generate update_controls4delta -U <URL to DISA STIGs downloads> [-J <profile_json_file.json>] 
-      [-c the_controls_directory --no-backupControls --no-formatControls -P <V or SV> -g -L debug]
+    $ saf generate update_controls4delta -U <URL to DISA STIGs downloads> [-J <profile_json_file.json> | -I </path/to/inspec-or-cinc-auditor>] [-c the_controls_directory --no-backupControls --no-formatControls -P <V or SV> -g -L debug]
 
 ```
 [top](#generate-data-reports-and-more)

--- a/src/commands/generate/delta.ts
+++ b/src/commands/generate/delta.ts
@@ -26,7 +26,7 @@ import {
 } from '../../utils/delta_matching';
 import { createWinstonLogger } from '../../utils/logging';
 import { BaseCommand } from '../../utils/oclif/base_command';
-import { basename, downloadFile, extractFileFromZip, getErrorMessage, resolveCincAuditor, resolveSafeChild } from '../../utils/global';
+import { basename, downloadFile, extractFileFromZip, getErrorMessage, resolveSafeChild } from '../../utils/global';
 
 /**
  * This class extends the capabilities of the update_controls4delta providing the following capabilities:
@@ -44,7 +44,11 @@ export default class GenerateDelta extends BaseCommand<typeof GenerateDelta> {
   static readonly flags = {
     inspecJsonFile: Flags.string({
       char: 'J', required: false, exclusive: ['interactive'],
-      description: 'InSpec Profile Controls JSON summary file - can be generated using the "[cinc-auditor or inspec] json <profile path> | jq . > profile.json" command',
+      description: '\u001B[31m(required [-J or -I])\u001B[34m InSpec Profile Controls JSON summary file - can be generated using the "[cinc-auditor or inspec] json <profile path> | jq . > profile.json" command',
+    }),
+    inspecPath: Flags.string({
+      char: 'I', required: false, exclusive: ['interactive'],
+      description: '\u001B[31m(required [-J or -I], and also with -M)\u001B[34m Absolute or known relative path to the inspec or cinc-auditor executable',
     }),
     xccdfXmlFile: Flags.string({
       char: 'X', exclusive: ['interactive', 'xccdfUrl'],
@@ -95,11 +99,11 @@ export default class GenerateDelta extends BaseCommand<typeof GenerateDelta> {
     },
     {
       description: '\u001B[93mProviding a XCCDF (File), a Profile Controls Summary, with Fuzzy matching)\u001B[0m',
-      command: '<%= config.bin %> <%= command.id %> -X <xccdf_benchmarks.[xml, zip]>, -J <profile_summary.json> -c <current-controls-dir> -o <updated_controls_dir>, -M, [options]',
+      command: '<%= config.bin %> <%= command.id %> -X <xccdf_benchmarks.[xml, zip]>, -J <profile_summary.json> -I </path/to/inspec-or-cinc-auditor> -c <current-controls-dir> -o <updated_controls_dir>, -M, [options]',
     },
     {
       description: '\u001B[93mProviding a XCCDF (URL), a Profile Controls Summary, with Fuzzy matching)\u001B[0m',
-      command: '<%= config.bin %> <%= command.id %> -U <URL-to-benchmark.zip>, -J <profile_summary.json> -c <current-controls-dir> -o <updated_controls_dir>, -M, [options]',
+      command: '<%= config.bin %> <%= command.id %> -U <URL-to-benchmark.zip>, -J <profile_summary.json> -I </path/to/inspec-or-cinc-auditor> -c <current-controls-dir> -o <updated_controls_dir>, -M, [options]',
     },
   ];
 
@@ -131,6 +135,12 @@ export default class GenerateDelta extends BaseCommand<typeof GenerateDelta> {
       this.error('\u001B[31mIf not interactive you must specify either [-X, --xccdfXmlFile or -U --xccdfUrl]\u001B[0m');
     }
 
+    // If not interactive, one input source is required for the initial profile load.
+    // When -M is used, -I is also required later to regenerate the mapped profile summary.
+    if (!flags.interactive && !flags.inspecJsonFile && !flags.inspecPath) {
+      this.error('\u001B[31mIf not interactive you must specify either [-J, --inspecJsonFile or -I, --inspecPath]\u001B[0m');
+    }
+
     // If not interactive and -J not provided the -c must be provided
     if (!flags.interactive && !flags.inspecJsonFile && !flags.controlsDir) {
       this.error('\u001B[31mIf not interactive and -J not provided the Controls Directory (-c) must be provided\u001B[0m');
@@ -138,6 +148,10 @@ export default class GenerateDelta extends BaseCommand<typeof GenerateDelta> {
 
     if (flags.runMapControls && !flags.controlsDir) {
       this.error('\u001B[31mIf not interactive and -M is provided the Controls Directory (-c) must be provided\u001B[0m');
+    }
+
+    if (!flags.interactive && flags.runMapControls && !flags.inspecPath) {
+      this.error('\u001B[31mIf not interactive and -M is provided the inspecPath (-I) must be provided\u001B[0m');
     }
 
     // Statics live for the process lifetime; explicitly reset them so that
@@ -158,6 +172,7 @@ export default class GenerateDelta extends BaseCommand<typeof GenerateDelta> {
 
     // Flag variables
     let inspecJsonFile: string;
+    let inspecPath: string;
     let xccdfXmlFile: string;
     let xccdfContent: string;
     let deltaOutputDir: string;
@@ -196,6 +211,7 @@ export default class GenerateDelta extends BaseCommand<typeof GenerateDelta> {
 
       // Optional flags
       inspecJsonFile = interactiveFlags.inspecJsonFile;
+      inspecPath = interactiveFlags.inspecPath;
       ovalXmlFile = interactiveFlags.ovalXmlFile;
       if (interactiveFlags.reportDirectory) {
         reportFile = path.join(interactiveFlags.reportDirectory, interactiveFlags.reportFileName);
@@ -216,6 +232,7 @@ export default class GenerateDelta extends BaseCommand<typeof GenerateDelta> {
 
       // Optional flags
       inspecJsonFile = flags.inspecJsonFile!;
+      inspecPath = flags.inspecPath as string;
       ovalXmlFile = flags.ovalXmlFile!;
       reportFile = flags.reportFile!;
       idType = flags.idType;
@@ -271,7 +288,7 @@ export default class GenerateDelta extends BaseCommand<typeof GenerateDelta> {
       try {
         this.logThis(`  Generating the summary file on directory: ${shortControlsDir}`, 'info');
         // Generate the profile controls summary from the `controlsDir` without the trailing "controls" directory
-        const inspecJsonFile = execFileSync(resolveCincAuditor(), ['json', path.dirname(controlsDir)], { encoding: 'utf8', maxBuffer: 50 * 1024 * 1024 });
+        const inspecJsonFile = execFileSync(inspecPath, ['json', path.dirname(controlsDir)], { encoding: 'utf8', maxBuffer: 50 * 1024 * 1024 });
         this.logThis('  Generated InSpec Profiles from InSpec JSON summary', 'info');
         existingProfile = processInSpecProfile(inspecJsonFile);
       } catch (error: unknown) {
@@ -411,7 +428,7 @@ export default class GenerateDelta extends BaseCommand<typeof GenerateDelta> {
           // Get the directory name without the trailing "controls" directory
           // Here we are using the newly updated (mapped) controls
           // const profileDir = path.dirname(controlsDir)
-          const inspecJsonFileNew = execFileSync(resolveCincAuditor(), ['json', path.dirname(mappedDir)], { encoding: 'utf8', maxBuffer: 50 * 1024 * 1024 });
+          const inspecJsonFileNew = execFileSync(inspecPath, ['json', path.dirname(mappedDir)], { encoding: 'utf8', maxBuffer: 50 * 1024 * 1024 });
 
           // Replace existing profile (inputted JSON of source profile to be mapped)
           // Allow delta to take care of the rest
@@ -1128,8 +1145,17 @@ export default class GenerateDelta extends BaseCommand<typeof GenerateDelta> {
       this.logger.info('inspecJsonFile=' + inspecJsonFile);
       interactiveValues.inspecJsonFile = inspecJsonFile;
     } else {
+      const inspecPath = await input({
+        message: 'Provide the absolute or known relative path to the inspec or cinc-auditor executable:',
+        validate(input: string) {
+          return input.trim().length > 0 || 'Please enter a path to the inspec or cinc-auditor executable';
+        },
+      });
+
       this.logger.info('inspecJsonFile=auto-generated');
+      this.logger.info('inspecPath=' + inspecPath);
       interactiveValues.inspecJsonFile = '';
+      interactiveValues.inspecPath = inspecPath;
     }
 
     // If we are using fuzzy logic or profile controls summary was not provided we need the controls directory

--- a/src/commands/generate/delta.ts
+++ b/src/commands/generate/delta.ts
@@ -1145,6 +1145,13 @@ export default class GenerateDelta extends BaseCommand<typeof GenerateDelta> {
       this.logger.info('inspecJsonFile=' + inspecJsonFile);
       interactiveValues.inspecJsonFile = inspecJsonFile;
     } else {
+      this.logger.info('inspecJsonFile=auto-generated');
+      interactiveValues.inspecJsonFile = '';
+    }
+
+    // If we are using fuzzy logic or profile controls summary was not provided we need the controls directory
+    const useFuzzyLogic = await confirm({ message: 'Run the approximate string matching process (fuzzy logic)?' });
+    if (useFuzzyLogic || generateSummaryFile === 'yes') {
       const inspecPath = await input({
         message: 'Provide the absolute or known relative path to the inspec or cinc-auditor executable:',
         validate(input: string) {
@@ -1152,15 +1159,9 @@ export default class GenerateDelta extends BaseCommand<typeof GenerateDelta> {
         },
       });
 
-      this.logger.info('inspecJsonFile=auto-generated');
       this.logger.info('inspecPath=' + inspecPath);
-      interactiveValues.inspecJsonFile = '';
       interactiveValues.inspecPath = inspecPath;
-    }
 
-    // If we are using fuzzy logic or profile controls summary was not provided we need the controls directory
-    const useFuzzyLogic = await confirm({ message: 'Run the approximate string matching process (fuzzy logic)?' });
-    if (useFuzzyLogic || generateSummaryFile === 'yes') {
       const controlsDir = await fileSelector({
         message: 'Select the Profile Controls directory (controls Delta is processing):',
         pageSize: 15,

--- a/src/commands/generate/delta.ts
+++ b/src/commands/generate/delta.ts
@@ -1103,7 +1103,7 @@ export default class GenerateDelta extends BaseCommand<typeof GenerateDelta> {
 
       this.logger.info('xccdfXmlFile=' + xccdfXmlFile);
       interactiveValues.xccdfTye = 'file';
-      interactiveValues.ovalXmlFile = xccdfXmlFile;
+      interactiveValues.xccdfXmlFile = xccdfXmlFile;
     } else {
       const xccdfUrl = await input({
         message: 'Provide an URL pointing to the XCCDF benchmark (.zip) package:',

--- a/src/commands/generate/delta.ts
+++ b/src/commands/generate/delta.ts
@@ -232,7 +232,7 @@ export default class GenerateDelta extends BaseCommand<typeof GenerateDelta> {
 
       // Optional flags
       inspecJsonFile = flags.inspecJsonFile!;
-      inspecPath = flags.inspecPath as string;
+      inspecPath = flags.inspecPath!;
       ovalXmlFile = flags.ovalXmlFile!;
       reportFile = flags.reportFile!;
       idType = flags.idType;
@@ -288,7 +288,7 @@ export default class GenerateDelta extends BaseCommand<typeof GenerateDelta> {
       try {
         this.logThis(`  Generating the summary file on directory: ${shortControlsDir}`, 'info');
         // Generate the profile controls summary from the `controlsDir` without the trailing "controls" directory
-        const inspecJsonFile = execFileSync(inspecPath, ['json', path.dirname(controlsDir)], { encoding: 'utf8', maxBuffer: 50 * 1024 * 1024 });
+        const inspecJsonFile = execFileSync(inspecPath, ['json', path.dirname(controlsDir)], { encoding: 'utf8', maxBuffer: 50 * 1024 * 1024, shell: process.platform === 'win32' });
         this.logThis('  Generated InSpec Profiles from InSpec JSON summary', 'info');
         existingProfile = processInSpecProfile(inspecJsonFile);
       } catch (error: unknown) {
@@ -428,7 +428,7 @@ export default class GenerateDelta extends BaseCommand<typeof GenerateDelta> {
           // Get the directory name without the trailing "controls" directory
           // Here we are using the newly updated (mapped) controls
           // const profileDir = path.dirname(controlsDir)
-          const inspecJsonFileNew = execFileSync(inspecPath, ['json', path.dirname(mappedDir)], { encoding: 'utf8', maxBuffer: 50 * 1024 * 1024 });
+          const inspecJsonFileNew = execFileSync(inspecPath, ['json', path.dirname(mappedDir)], { encoding: 'utf8', maxBuffer: 50 * 1024 * 1024, shell: process.platform === 'win32' });
 
           // Replace existing profile (inputted JSON of source profile to be mapped)
           // Allow delta to take care of the rest

--- a/src/commands/generate/update_controls4delta.ts
+++ b/src/commands/generate/update_controls4delta.ts
@@ -11,7 +11,7 @@ import {
 import { Flags } from '@oclif/core';
 import tmp from 'tmp';
 import type { Logger } from 'winston';
-import { basename, downloadFile, extractFileFromZip, getErrorMessage, resolveCincAuditor } from '../../utils/global';
+import { basename, downloadFile, extractFileFromZip, getErrorMessage } from '../../utils/global';
 import { createWinstonLogger } from '../../utils/logging';
 import { BaseCommand } from '../../utils/oclif/base_command';
 
@@ -50,11 +50,11 @@ export default class GenerateUpdateControls extends BaseCommand<typeof GenerateU
   static readonly examples = [
     {
       description: '\u001B[93mProviding an XCCDF File\u001B[0m',
-      command: '<%= config.bin %> <%= command.id %> -X ./the_xccdf_guidance_file.xml [-J <profile_json_file.json>] [-c the_controls_directory --no-backupControls --no-formatControls -P <V or SV> -g -L debug]',
+      command: '<%= config.bin %> <%= command.id %> -X ./the_xccdf_guidance_file.xml [-J <profile_json_file.json> | -I </path/to/inspec-or-cinc-auditor>] [-c the_controls_directory --no-backupControls --no-formatControls -P <V or SV> -g -L debug]',
     },
     {
       description: '\u001B[93mProviding an URL point to an ZIP XCCDF (from DISA STIG downloads)\u001B[0m',
-      command: '<%= config.bin %> <%= command.id %> -U <URL to DISA STIGs downloads> [-J <profile_json_file.json>] [-c the_controls_directory --no-backupControls --no-formatControls -P <V or SV> -g -L debug]',
+      command: '<%= config.bin %> <%= command.id %> -U <URL to DISA STIGs downloads> [-J <profile_json_file.json> | -I </path/to/inspec-or-cinc-auditor>] [-c the_controls_directory --no-backupControls --no-formatControls -P <V or SV> -g -L debug]',
     },
   ];
 
@@ -70,8 +70,12 @@ export default class GenerateUpdateControls extends BaseCommand<typeof GenerateU
       exclusive: ['xccdfXmlFile'],
     }),
     inspecJsonFile: Flags.string({
-      char: 'J', required: false,
-      description: 'InSpec Profiles JSON summary file - can be generated using the "cinc-auditor or inspec] json <profile path> > profile.json" command',
+      char: 'J', required: false, exactlyOne: ['inspecPath'],
+      description: '\u001B[31m(required [-J or -I])\u001B[34m InSpec Profiles JSON summary file - can be generated using the "[cinc-auditor or inspec] json <profile path> > profile.json" command',
+    }),
+    inspecPath: Flags.string({
+      char: 'I', required: false, exactlyOne: ['inspecJsonFile'],
+      description: '\u001B[31m(required [-J or -I])\u001B[34m Absolute or known relative path to the inspec or cinc-auditor executable',
     }),
     controlsDir: Flags.string({
       char: 'c', required: true,
@@ -103,6 +107,10 @@ export default class GenerateUpdateControls extends BaseCommand<typeof GenerateU
 
     if (!flags.xccdfXmlFile && !flags.xccdfUrl) {
       this.error('\u001B[31mYou must specify either [-X, --xccdfXmlFile or -U --xccdfUrl]\u001B[0m');
+    }
+
+    if (!flags.inspecJsonFile && !flags.inspecPath) {
+      this.error('\u001B[31mYou must specify either [-J, --inspecJsonFile or -I, --inspecPath]\u001B[0m');
     }
 
     const logger = createWinstonLogger({ module: 'generate:update_controls', level: flags.logLevel });
@@ -250,12 +258,13 @@ export default class GenerateUpdateControls extends BaseCommand<typeof GenerateU
         throw new Error('Unknown error occurred while processing the input JSON.', { cause: error });
       }
     } else {
+      const inspecPath = flags.inspecPath as string;
       // Generate the profile json
       try {
         logger.info(`  Generating the summary file on directory: ${shortControlsDir}`);
         // Get the directory name without the trailing "controls" directory
         const profileDir = path.dirname(flags.controlsDir);
-        const inspecJsonFile = execFileSync(resolveCincAuditor(), ['json', profileDir], { encoding: 'utf8', maxBuffer: 50 * 1024 * 1024 });
+        const inspecJsonFile = execFileSync(inspecPath, ['json', profileDir], { encoding: 'utf8', maxBuffer: 50 * 1024 * 1024 });
 
         logger.info('Generating InSpec Profiles from InSpec JSON summary');
         inspecProfile = processInSpecProfile(inspecJsonFile);

--- a/src/commands/generate/update_controls4delta.ts
+++ b/src/commands/generate/update_controls4delta.ts
@@ -258,13 +258,13 @@ export default class GenerateUpdateControls extends BaseCommand<typeof GenerateU
         throw new Error('Unknown error occurred while processing the input JSON.', { cause: error });
       }
     } else {
-      const inspecPath = flags.inspecPath as string;
+      const inspecPath = flags.inspecPath!;
       // Generate the profile json
       try {
         logger.info(`  Generating the summary file on directory: ${shortControlsDir}`);
         // Get the directory name without the trailing "controls" directory
         const profileDir = path.dirname(flags.controlsDir);
-        const inspecJsonFile = execFileSync(inspecPath, ['json', profileDir], { encoding: 'utf8', maxBuffer: 50 * 1024 * 1024 });
+        const inspecJsonFile = execFileSync(inspecPath, ['json', profileDir], { encoding: 'utf8', maxBuffer: 50 * 1024 * 1024, shell: process.platform === 'win32' });
 
         logger.info('Generating InSpec Profiles from InSpec JSON summary');
         inspecProfile = processInSpecProfile(inspecJsonFile);

--- a/src/utils/global.ts
+++ b/src/utils/global.ts
@@ -1,4 +1,3 @@
-import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fingerprint, Assettype, INPUT_TYPES, Role, Techarea } from '@mitre/hdf-converters';
@@ -19,45 +18,6 @@ export function checkSuffix(input: string, suffix = '.json') {
   }
 
   return `${input}${suffix}`;
-}
-
-/**
- * Resolve the absolute path of the `cinc-auditor` executable, or throw with
- * a clear error if it's not installed / not in PATH. Used by the
- * `generate delta` + `generate update_controls4delta` flows so the
- * downstream `execFileSync` call receives a fully-qualified path rather
- * than a bare binary name (satisfies Sonar S4036 — don't trust $PATH
- * resolution at the moment of spawn).
- *
- * Cross-platform: uses `where` on Windows and `which` on POSIX.
- * Memoizes the result per-process so subsequent calls don't re-probe.
- */
-let _cincAuditorPath: string | undefined;
-export function resolveCincAuditor(): string {
-  if (_cincAuditorPath !== undefined) {
-    return _cincAuditorPath;
-  }
-  const isWindows = process.platform === 'win32';
-  // `execFileSync` with a fixed lookup command + fixed arg ('cinc-auditor')
-  // — no user input reaches the subprocess. `which`/`where` is available
-  // on all supported platforms (POSIX which, Windows where).
-  try {
-    const result = execFileSync(
-      isWindows ? 'where' : 'which',
-      ['cinc-auditor'],
-      { encoding: 'utf8' },
-    ).toString().trim().split(/\r?\n/)[0];
-    if (!result) {
-      throw new Error('cinc-auditor not found on PATH');
-    }
-    _cincAuditorPath = result;
-    return result;
-  } catch (error: unknown) {
-    throw new Error(
-      'cinc-auditor executable not found. Install cinc-auditor (https://cinc.sh/start/auditor/) and ensure it is on PATH before running `saf generate delta` without a pre-generated -J profile summary.',
-      { cause: error },
-    );
-  }
 }
 
 /**

--- a/test/commands/generate/delta.test.ts
+++ b/test/commands/generate/delta.test.ts
@@ -100,11 +100,25 @@ describe.sequential('Test generate delta command', () => {
     assert.isTrue(isFile);
   });
 
+  it('should require --inspecPath when using fuzzy logic to match and map controls', async () => {
+    const { stderr } = await runCommand<{ name: string }>([
+      'generate delta',
+      '-J', path.resolve('./test/sample_data/inspec/json/profile_and_controls/Windows_Server_2019_v1r3_mini-profile.json'),
+      '-X', path.resolve('./test/sample_data/xccdf/stigs/Windows_Server_2022_V2R1_mini-sample-xccdf.xml'),
+      '-o', `${tmpobj.name}`,
+      '-M',
+      '-c', path.resolve('./test/sample_data/inspec/json/profile_and_controls/windows_server_2019_v1r3_mini_controls/'),
+    ]);
+    expect(stderr).to.include('-M');
+    expect(stderr).to.include('inspecPath');
+  });
+
   // should process delta using the fuzzy logic
   it('should generate the correct number of controls using fuzzy logic to match and map controls', async () => {
     const { stdout } = await runCommand<{ name: string }>([
       'generate delta',
       '-J', path.resolve('./test/sample_data/inspec/json/profile_and_controls/Windows_Server_2019_v1r3_mini-profile.json'),
+      '-I', 'cinc-auditor',
       '-X', path.resolve('./test/sample_data/xccdf/stigs/Windows_Server_2022_V2R1_mini-sample-xccdf.xml'),
       '-o', `${tmpobj.name}`,
       '-M',

--- a/test/commands/generate/delta_interactive.test.ts
+++ b/test/commands/generate/delta_interactive.test.ts
@@ -1,0 +1,168 @@
+import { input, confirm, select } from '@inquirer/prompts';
+import fileSelector from 'inquirer-file-selector';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import GenerateDelta from '../../../src/commands/generate/delta';
+
+vi.mock('@inquirer/prompts', () => ({
+  confirm: vi.fn(),
+  input: vi.fn(),
+  select: vi.fn(),
+}));
+
+vi.mock('inquirer-file-selector', () => ({
+  default: vi.fn(),
+}));
+
+vi.mock('chalk', () => ({
+  default: {
+    blueBright: String,
+    green: String,
+    yellow: String,
+  },
+}));
+
+type LoggerStub = {
+  debug: ReturnType<typeof vi.fn>;
+  error: ReturnType<typeof vi.fn>;
+  info: ReturnType<typeof vi.fn>;
+  warn: ReturnType<typeof vi.fn>;
+};
+
+type TestableGenerateDelta = {
+  getFlags: () => Promise<Record<string, unknown>>;
+  logger: LoggerStub;
+};
+
+const confirmMock = vi.mocked(confirm);
+const fileSelectorMock = vi.mocked(fileSelector);
+const inputMock = vi.mocked(input);
+const selectMock = vi.mocked(select);
+
+const logger: LoggerStub = {
+  debug: vi.fn(),
+  error: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+};
+
+function createCommand(): TestableGenerateDelta {
+  const command = Object.create(GenerateDelta.prototype) as TestableGenerateDelta;
+  command.logger = logger;
+  return command;
+}
+
+function shiftPromptValue<T>(values: T[], promptType: string): T {
+  const value = values.shift();
+  if (value === undefined) {
+    throw new Error(`No mocked ${promptType} value available`);
+  }
+
+  return value;
+}
+
+function mockPromptFlow({
+  confirms,
+  files,
+  inputs,
+  selects,
+}: {
+  confirms: boolean[];
+  files: string[];
+  inputs: string[];
+  selects: string[];
+}) {
+  confirmMock.mockImplementation(() => Promise.resolve(shiftPromptValue(confirms, 'confirm')));
+  fileSelectorMock.mockImplementation(() => Promise.resolve(shiftPromptValue(files, 'file selector')));
+  inputMock.mockImplementation(() => Promise.resolve(shiftPromptValue(inputs, 'input')));
+  selectMock.mockImplementation(() => Promise.resolve(shiftPromptValue(selects, 'select')));
+}
+
+function inputMessages(): string[] {
+  return inputMock.mock.calls.map(([question]) => question.message);
+}
+
+describe.sequential('Test generate delta interactive prompt flow', () => {
+  beforeEach(() => {
+    confirmMock.mockReset();
+    fileSelectorMock.mockReset();
+    inputMock.mockReset();
+    selectMock.mockReset();
+
+    logger.debug.mockReset();
+    logger.error.mockReset();
+    logger.info.mockReset();
+    logger.warn.mockReset();
+  });
+
+  it('should prompt for the inspec path when using an existing profile summary with fuzzy mapping', async () => {
+    mockPromptFlow({
+      confirms: [true, false, false],
+      files: ['/tmp/profile.json', '/tmp/profile/controls', '/tmp/delta-output'],
+      inputs: ['https://example.test/stig.zip', 'cinc-auditor'],
+      selects: ['url', 'no', 'rule', 'info'],
+    });
+
+    const flags = await createCommand().getFlags();
+
+    expect(flags).toMatchObject({
+      controlsDir: '/tmp/profile/controls',
+      deltaOutputDir: '/tmp/delta-output',
+      idType: 'rule',
+      inspecJsonFile: '/tmp/profile.json',
+      inspecPath: 'cinc-auditor',
+      logLevel: 'info',
+      runMapControls: true,
+      xccdfTye: 'url',
+      xccdfUrl: 'https://example.test/stig.zip',
+    });
+    expect(inputMessages()).toContain('Provide the absolute or known relative path to the inspec or cinc-auditor executable:');
+  });
+
+  it('should not prompt for the inspec path when using an existing profile summary without fuzzy mapping', async () => {
+    mockPromptFlow({
+      confirms: [false, false, false],
+      files: ['/tmp/profile.json', '/tmp/delta-output'],
+      inputs: ['https://example.test/stig.zip'],
+      selects: ['url', 'no', 'group', 'warn'],
+    });
+
+    const flags = await createCommand().getFlags();
+
+    expect(flags).toMatchObject({
+      deltaOutputDir: '/tmp/delta-output',
+      idType: 'group',
+      inspecJsonFile: '/tmp/profile.json',
+      logLevel: 'warn',
+      runMapControls: false,
+      xccdfTye: 'url',
+      xccdfUrl: 'https://example.test/stig.zip',
+    });
+    expect(flags).not.toHaveProperty('controlsDir');
+    expect(flags).not.toHaveProperty('inspecPath');
+    expect(inputMessages()).not.toContain('Provide the absolute or known relative path to the inspec or cinc-auditor executable:');
+  });
+
+  it('should prompt for the inspec path when auto-generating the profile summary without fuzzy mapping', async () => {
+    mockPromptFlow({
+      confirms: [false, false, false],
+      files: ['/tmp/profile/controls', '/tmp/delta-output'],
+      inputs: ['https://example.test/stig.zip', '/opt/cinc-auditor/bin/cinc-auditor'],
+      selects: ['url', 'yes', 'version', 'debug'],
+    });
+
+    const flags = await createCommand().getFlags();
+
+    expect(flags).toMatchObject({
+      controlsDir: '/tmp/profile/controls',
+      deltaOutputDir: '/tmp/delta-output',
+      idType: 'version',
+      inspecJsonFile: '',
+      inspecPath: '/opt/cinc-auditor/bin/cinc-auditor',
+      logLevel: 'debug',
+      runMapControls: false,
+      xccdfTye: 'url',
+      xccdfUrl: 'https://example.test/stig.zip',
+    });
+    expect(inputMessages()).toContain('Provide the absolute or known relative path to the inspec or cinc-auditor executable:');
+  });
+});

--- a/test/commands/generate/update_controls4delta.test.ts
+++ b/test/commands/generate/update_controls4delta.test.ts
@@ -8,7 +8,7 @@ import { describe, expect, it } from 'vitest';
 describe('Test generate update_controls4delta command', () => {
   // This command updates controls in place, so tests must operate on a temp copy
   // of the fixture controls rather than the checked-in sample files
-  it('should rename legacy controls to the new XCCDF control ids', async () => {
+  it('should rename legacy controls to the new XCCDF control ids using --inspecJsonFile', async () => {
     const tempWorkspace = tmp.dirSync({ unsafeCleanup: true });
     const sourceControlsDir = path.resolve('./test/sample_data/inspec/json/profile_and_controls/windows_server_2019_v1r3_mini_controls');
     const tempControlsDir = path.join(tempWorkspace.name, 'controls');
@@ -38,6 +38,37 @@ describe('Test generate update_controls4delta command', () => {
     expect(fs.existsSync(path.join(tempControlsDir, 'SV-205661.rb'))).to.eql(true);
 
     // The original legacy control filenames should no longer exist
+    expect(fs.existsSync(path.join(tempControlsDir, 'V-93369.rb'))).to.eql(false);
+    expect(fs.existsSync(path.join(tempControlsDir, 'V-93205.rb'))).to.eql(false);
+    expect(fs.existsSync(path.join(tempControlsDir, 'V-93207.rb'))).to.eql(false);
+    expect(fs.existsSync(path.join(tempControlsDir, 'V-93473.rb'))).to.eql(false);
+    expect(fs.existsSync(path.join(tempControlsDir, 'V-93461.rb'))).to.eql(false);
+  });
+
+  it('should rename legacy controls to the new XCCDF control ids using --inspecPath', async () => {
+    const tempWorkspace = tmp.dirSync({ unsafeCleanup: true });
+    const sourceControlsDir = path.resolve('./test/sample_data/inspec/json/profile_and_controls/windows_server_2019_v1r3_mini_controls');
+    const tempControlsDir = path.join(tempWorkspace.name, 'controls');
+
+    fs.cpSync(sourceControlsDir, tempControlsDir, { recursive: true });
+
+    await runCommand<{ name: string }>([
+      'generate update_controls4delta',
+      '-I', 'cinc-auditor',
+      '-X', path.resolve('./test/sample_data/xccdf/stigs/Windows_Server_2019_V3R2_xccdf.xml'),
+      '-c', tempControlsDir,
+      '--no-backupControls',
+    ]);
+
+    const fileCount = fs.readdirSync(tempControlsDir).length;
+    expect(fileCount).to.eql(5);
+
+    expect(fs.existsSync(path.join(tempControlsDir, 'SV-205844.rb'))).to.eql(true);
+    expect(fs.existsSync(path.join(tempControlsDir, 'SV-205845.rb'))).to.eql(true);
+    expect(fs.existsSync(path.join(tempControlsDir, 'SV-205846.rb'))).to.eql(true);
+    expect(fs.existsSync(path.join(tempControlsDir, 'SV-205657.rb'))).to.eql(true);
+    expect(fs.existsSync(path.join(tempControlsDir, 'SV-205661.rb'))).to.eql(true);
+
     expect(fs.existsSync(path.join(tempControlsDir, 'V-93369.rb'))).to.eql(false);
     expect(fs.existsSync(path.join(tempControlsDir, 'V-93205.rb'))).to.eql(false);
     expect(fs.existsSync(path.join(tempControlsDir, 'V-93207.rb'))).to.eql(false);


### PR DESCRIPTION
1) remove the resolve cinc auditor path function which does not actually properly resolve the security hotspot described by SonarQube's javascript:S4036.  what it did was grab the first version of the cinc-auditor binary off of the path and use that the entire time.  the security hotspot says that leveraging the path at all is what is the security concern.

2) instead we tell the user to supply us a path to an inspec or cinc auditor binary.

3) added some tests to validate that everything still works

4) fixed some bugs that we found along the way