### PR TITLE
Update Iron Bank MR jobs to update both amd64 and arm64 architectures

### DIFF
--- a/.github/workflows/push-to-docker-main.yml
+++ b/.github/workflows/push-to-docker-main.yml
@@ -30,7 +30,7 @@ jobs:
           push: true
           platforms: "linux/amd64,linux/arm64"
           tags: mitre/saf:latest,mitre/saf:${{ github.sha }}
-      - name: Get Docker SHA since the Iron Bank release requires us to specify the exact resources we need them to pull into the environment
+      - name: Get the per-architecture Docker SHAs since the Iron Bank Dockerfiles require us to specify the exact per-architecture resources we need them to pull into the environment
         shell: bash
         id: get-docker-sha
         run: |
@@ -51,7 +51,14 @@ jobs:
           done
 
           if [ "$SUCCESS" = true ]; then
-            echo "DOCKER_SHA=$(docker inspect --format='{{index .RepoDigests 0}}' mitre/saf:${{ github.sha }} | cut -d '@' -f 2)" >> $GITHUB_ENV
+            # The image is multi-arch, so the tag resolves to an OCI index (manifest list).
+            # Iron Bank maintains a per-architecture Dockerfile, so each one needs the digest of
+            # its specific child manifest (amd64 / arm64), not the index digest.
+            MANIFEST=$(docker buildx imagetools inspect mitre/saf:${{ github.sha }} --raw)
+            AMD64_SHA=$(echo "$MANIFEST" | jq -r '.manifests[] | select(.platform.architecture=="amd64" and .platform.os=="linux") | .digest')
+            ARM64_SHA=$(echo "$MANIFEST" | jq -r '.manifests[] | select(.platform.architecture=="arm64" and .platform.os=="linux") | .digest')
+            echo "DOCKER_SHA=${AMD64_SHA}" >> $GITHUB_ENV
+            echo "DOCKER_SHA_ARM64=${ARM64_SHA}" >> $GITHUB_ENV
           else
             echo "Docker pull failed after $MAX_RETRIES attempts."
             exit 1
@@ -68,5 +75,6 @@ jobs:
           git_commit_author_name: "Automated SAF CLI Release"
           git_commit_author_email: "saf@mitre.org"
           update_commands: |
-            yq e -i '.args.SAF_VERSION=\"${{ github.sha }}\" | .tags[0]=\"${{ github.sha }}\" | .labels.\"org.opencontainers.image.version\"=\"${{ github.sha }}\" | .resources[0].tag=\"mitre/saf:${{ github.sha }}\" | .resources[0].url=\"docker://docker.io/mitre/saf@${{ env.DOCKER_SHA }}\"' hardening_manifest.yaml
+            yq e -i '.args.SAF_VERSION=\"${{ github.sha }}\" | .tags[0]=\"${{ github.sha }}\" | .labels.\"org.opencontainers.image.version\"=\"${{ github.sha }}\" | .resources[0].tag=\"mitre/saf:${{ github.sha }}\" | .resources[0].url=\"docker://docker.io/mitre/saf@${{ env.DOCKER_SHA }}\" | .resources[1].tag=\"mitre/saf:${{ github.sha }}.arm64\" | .resources[1].url=\"docker://docker.io/mitre/saf@${{ env.DOCKER_SHA_ARM64 }}\"' hardening_manifest.yaml
             sed -i s/SAF_VERSION=\.\*/SAF_VERSION=${{ github.sha }}/ Dockerfile
+            sed -i s/SAF_VERSION=\.\*/SAF_VERSION=${{ github.sha }}-arm64/ Dockerfile.arm64

--- a/.github/workflows/push-to-docker.yml
+++ b/.github/workflows/push-to-docker.yml
@@ -43,7 +43,7 @@ jobs:
           push: true
           platforms: "linux/amd64,linux/arm64"
           tags: mitre/saf:release-latest,mitre/saf:${{ steps.format-tag.outputs.replaced }},mitre/saf:v1
-      - name: Get Docker SHA since the Iron Bank release requires us to specify the exact resources we need them to pull into the environment
+      - name: Get the per-architecture Docker SHAs since the Iron Bank Dockerfiles require us to specify the exact per-architecture resources we need them to pull into the environment
         shell: bash
         id: get-docker-sha
         run: |
@@ -64,7 +64,14 @@ jobs:
           done
 
           if [ "$SUCCESS" = true ]; then
-            echo "DOCKER_SHA=$(docker inspect --format='{{index .RepoDigests 0}}' mitre/saf:${{ steps.format-tag.outputs.replaced }} | cut -d '@' -f 2)" >> $GITHUB_ENV
+            # The image is multi-arch, so the tag resolves to an OCI index (manifest list).
+            # Iron Bank maintains a per-architecture Dockerfile, so each one needs the digest of
+            # its specific child manifest (amd64 / arm64), not the index digest.
+            MANIFEST=$(docker buildx imagetools inspect mitre/saf:${{ steps.format-tag.outputs.replaced }} --raw)
+            AMD64_SHA=$(echo "$MANIFEST" | jq -r '.manifests[] | select(.platform.architecture=="amd64" and .platform.os=="linux") | .digest')
+            ARM64_SHA=$(echo "$MANIFEST" | jq -r '.manifests[] | select(.platform.architecture=="arm64" and .platform.os=="linux") | .digest')
+            echo "DOCKER_SHA=${AMD64_SHA}" >> $GITHUB_ENV
+            echo "DOCKER_SHA_ARM64=${ARM64_SHA}" >> $GITHUB_ENV
           else
             echo "Docker pull failed after $MAX_RETRIES attempts."
             exit 1
@@ -81,5 +88,6 @@ jobs:
           git_commit_author_name: "Automated SAF CLI Release"
           git_commit_author_email: "saf@mitre.org"
           update_commands: |
-            yq e -i '.args.SAF_VERSION=\"${{ steps.format-tag.outputs.replaced }}\" | .tags[0]=\"${{ steps.format-tag.outputs.replaced }}\" | .labels.\"org.opencontainers.image.version\"=\"${{ steps.format-tag.outputs.replaced }}\" | .resources[0].tag=\"mitre/saf:${{ steps.format-tag.outputs.replaced }}\" | .resources[0].url=\"docker://docker.io/mitre/saf@${{ env.DOCKER_SHA }}\"' hardening_manifest.yaml
+            yq e -i '.args.SAF_VERSION=\"${{ steps.format-tag.outputs.replaced }}\" | .tags[0]=\"${{ steps.format-tag.outputs.replaced }}\" | .labels.\"org.opencontainers.image.version\"=\"${{ steps.format-tag.outputs.replaced }}\" | .resources[0].tag=\"mitre/saf:${{ steps.format-tag.outputs.replaced }}\" | .resources[0].url=\"docker://docker.io/mitre/saf@${{ env.DOCKER_SHA }}\" | .resources[1].tag=\"mitre/saf:${{ steps.format-tag.outputs.replaced }}.arm64\" | .resources[1].url=\"docker://docker.io/mitre/saf@${{ env.DOCKER_SHA_ARM64 }}\"' hardening_manifest.yaml
             sed -i s/SAF_VERSION=\.\*/SAF_VERSION=${{ steps.format-tag.outputs.replaced }}/ Dockerfile
+            sed -i s/SAF_VERSION=\.\*/SAF_VERSION=${{ steps.format-tag.outputs.replaced }}-arm64/ Dockerfile.arm64


### PR DESCRIPTION
Pull the amd64 and arm64 child-manifest digests from the OCI index instead of the index digest, and update both the Dockerfile (amd64) and Dockerfile.arm64 resources in a single Iron Bank MR for the saf and saf-mainline repos.