### PR TITLE
Fix/delta 1n split body collision

### DIFF
--- a/src/commands/generate/delta.ts
+++ b/src/commands/generate/delta.ts
@@ -812,9 +812,10 @@ export default class GenerateDelta extends BaseCommand<typeof GenerateDelta> {
           : `old control ${oldId}:`;
         const rows = items
           .map((l) => {
+            // `related` links never carry potentialMismatch (it is a primary-
+            // only flag), so the per-row risk signal is the confidence itself.
             const conf = `${(l.confidence * 100).toFixed(0)}%`;
-            const flag = l.potentialMismatch ? '  ** potential mismatch **' : '';
-            return `    related -> ${basename(l.newId)}  [${l.matchMethod}, confidence=${conf}]${flag}`;
+            return `    related -> ${basename(l.newId)}  [${l.matchMethod}, confidence=${conf}]`;
           })
           .join('\n');
         return `${head}\n${rows}`;

--- a/src/commands/generate/delta.ts
+++ b/src/commands/generate/delta.ts
@@ -593,8 +593,9 @@ export default class GenerateDelta extends BaseCommand<typeof GenerateDelta> {
               + `                 No Match Controls: ${GenerateDelta.noMatch}\n`
               + `                New XCCDF Controls: ${GenerateDelta.newXccdfControl}\n\n`
               + 'Statistics Validation ------------------------------------------\n'
-              + `Match + Mismatch + Related = Total Mapped Controls: ${this.getMappedStatisticsValidation(totalMappedControls, 'totalMapped')}\n`
+              + `Match + Mismatch = Total Mapped Controls: ${this.getMappedStatisticsValidation(totalMappedControls, 'totalMapped')}\n`
               + `  Total Processed = Total XCCDF Controls: ${this.getMappedStatisticsValidation(totalMappedControls, 'totalProcessed')}\n\n`
+              + GenerateDelta.formatRelatedControlsReport(GenerateDelta.links)
               + updatedResult.markdown;
             fs.writeFileSync(markDownFile, reportData);
           } else {
@@ -654,14 +655,15 @@ export default class GenerateDelta extends BaseCommand<typeof GenerateDelta> {
     //                                                              keys=['title','gtitle']
     //
     // 1:N splits (multiple new controls resolving to the same old) are
-    // preserved as primary + related links. Both land in the returned
-    // controlMappings so downstream file-writing copies the old Ruby
-    // body to every new control that shares the requirement.
+    // preserved as primary + related links, but only the PRIMARY is added to
+    // controlMappings and inherits the old Ruby body. Related links are kept
+    // in delta.json links[] for visibility and are emitted as new controls
+    // without a body (the author writes them) — copying one body onto several
+    // distinct new controls would duplicate / misattribute test code.
     //
     // Existing static counters on GenerateDelta are reused to keep the
-    // summary output format stable; `dupMatch` is repurposed to count
-    // `related` links (it used to count rejected duplicates in the
-    // former 1:1 model).
+    // summary output format stable; `dupMatch` counts `related` links (the
+    // not-given-a-body duplicates), as in the original 1:1 model.
     const oldControls: Control[] = oldProfile.controls;
     const newControls: Control[] = newProfile.controls;
     GenerateDelta.oldControlsLength = oldControls.length;
@@ -697,9 +699,22 @@ export default class GenerateDelta extends BaseCommand<typeof GenerateDelta> {
         continue;
       }
 
-      // Every non-none link resolves to an old control and goes into the
-      // returned map. Primary and related both need the old Ruby body.
-      controlMappings[newId] = link.oldId;
+      // Only the PRIMARY (best) match to an old control inherits its Ruby
+      // body. A `related` link is a weaker/secondary new control whose
+      // primary already claimed that old body; copying it here would
+      // duplicate the same test code across distinct controls (and, for
+      // spurious SRG/CCI co-bucketing, graft outright wrong code). Related
+      // controls are instead emitted as new controls WITHOUT a body for the
+      // author to fill — matching the original matcher's "best match wins the
+      // body, duplicates are skipped" behavior. They remain in
+      // delta.json links[] (and the dupMatch counter) for triage visibility.
+      //
+      // This also guarantees each old id appears at most once in
+      // controlMappings, so the mapped-control file write (keyed by old id)
+      // cannot collide between siblings of a 1:N split.
+      if (link.relationship === 'primary') {
+        controlMappings[newId] = link.oldId;
+      }
 
       this.logger.info(`Processing New Control:  ${newId}`);
       if (newCtl?.title) {
@@ -712,7 +727,14 @@ export default class GenerateDelta extends BaseCommand<typeof GenerateDelta> {
       GenerateDelta.logMatchMethod(this.logger, link);
       GenerateDelta.tickMatchCounter(link);
 
-      this.logger.info(`  Best Match Candidate:  ${link.oldId} --> ${newId}\n`);
+      // Distinguish primaries (which inherit the body) from related links
+      // (best match for an already-claimed old control; emitted WITHOUT a
+      // body) so the log doesn't read as if a related control was mapped.
+      if (link.relationship === 'related') {
+        this.logger.info(`  Related (no body copied):  ${newId} ~ best match ${link.oldId}\n`);
+      } else {
+        this.logger.info(`  Best Match Candidate:  ${link.oldId} --> ${newId}\n`);
+      }
     }
 
     this.logger.info('Mapping Results ===========================================================================');
@@ -736,10 +758,41 @@ export default class GenerateDelta extends BaseCommand<typeof GenerateDelta> {
     this.logger.info(`                New XCCDF Controls:  ${GenerateDelta.newXccdfControl}\n`);
 
     this.logger.info('Statistics Validation =============================================');
-    this.logger.info(`Match + Mismatch + Related = Total Mapped:  ${this.getMappedStatisticsValidation(totalMappedControls, 'totalMapped')}`);
+    this.logger.info(`Match + Mismatch = Total Mapped:  ${this.getMappedStatisticsValidation(totalMappedControls, 'totalMapped')}`);
     this.logger.info(`  Total Processed = Total XCCDF Controls:  ${this.getMappedStatisticsValidation(totalMappedControls, 'totalProcessed')}\n\n`);
 
     return controlMappings;
+  }
+
+  /**
+   * Build a human-readable report section listing every `related` link — new
+   * controls that matched an old control but were not its primary (best)
+   * match, so no control body was copied forward. These are emitted as
+   * bodiless new controls; surfacing them (sorted by confidence, highest
+   * first) lets a reviewer spot close matches that may warrant manual body
+   * reuse or careful authoring. Returns '' when there are no related links.
+   */
+  private static formatRelatedControlsReport(links: LinkRecord[]): string {
+    const related = links
+      .filter(l => l.relationship === 'related')
+      .toSorted((a, b) => b.confidence - a.confidence);
+    if (related.length === 0) {
+      return '';
+    }
+    const rows = related
+      .map((l) => {
+        const conf = `${(l.confidence * 100).toFixed(0)}%`;
+        const flag = l.potentialMismatch ? '  ** potential mismatch **' : '';
+        return `  ${basename(l.newId)}  ~ best match ${l.oldId}  [${l.matchMethod}, confidence=${conf}]${flag}`;
+      })
+      .join('\n');
+    return '## Related Controls (no body copied)\n'
+      + 'These new controls matched an old control but were not its primary (best)\n'
+      + 'match, so no control body was copied forward — they are emitted as new\n'
+      + 'controls without a body. Review the higher-confidence matches: a close one\n'
+      + 'may warrant manually reusing the old body or careful authoring.\n\n'
+      + rows
+      + `\n\nTotal Related (no body copied): ${related.length}\n\n`;
   }
 
   /**
@@ -783,9 +836,9 @@ export default class GenerateDelta extends BaseCommand<typeof GenerateDelta> {
    * Advance the GenerateDelta static counters for a single link so the
    * end-of-run stats match reality.
    *
-   *   match        -> primary link, high confidence
-   *   posMisMatch  -> primary link, lower confidence (still accepted)
-   *   dupMatch     -> related link (shares old body with an earlier primary)
+   *   match        -> primary link, high confidence (gets the old body)
+   *   posMisMatch  -> primary link, lower confidence (still accepted, gets body)
+   *   dupMatch     -> related link (secondary match; emitted without a body)
    */
   private static tickMatchCounter(link: LinkRecord): void {
     if (link.relationship === 'related') {
@@ -805,20 +858,21 @@ export default class GenerateDelta extends BaseCommand<typeof GenerateDelta> {
   }
 
   getMappedStatisticsValidation(totalMappedControls: number, statValidation: string): string {
-    // In the requirement-first pipeline `dupMatch` counts `related` links,
-    // which ARE included in controlMappings (they share a body with a
-    // primary). `newXccdfControl` is kept at 0 because the new pipeline
-    // doesn't have a distinct "no Fuse candidate" bucket — those fall
-    // into `noMatch`.
+    // Only PRIMARY links are added to controlMappings (they inherit the old
+    // body), so totalMapped == match + posMisMatch. `related` links
+    // (`dupMatch`) are NOT mapped — they are emitted as bodiless new controls
+    // — so the full new-profile accounting is mapped + related + noMatch.
+    // `newXccdfControl` is kept at 0 because the requirement-first pipeline
+    // has no distinct "no Fuse candidate" bucket — those fall into `noMatch`.
     const match = GenerateDelta.match;
     const misMatch = GenerateDelta.posMisMatch;
     const related = GenerateDelta.dupMatch;
     const noMatch = GenerateDelta.noMatch;
-    const statMappedMatches = (match + misMatch + related) === totalMappedControls;
-    const statProcessedTotal = (totalMappedControls + noMatch) === GenerateDelta.newControlsLength;
+    const statMappedMatches = (match + misMatch) === totalMappedControls;
+    const statProcessedTotal = (totalMappedControls + related + noMatch) === GenerateDelta.newControlsLength;
     return statValidation === 'totalMapped'
-      ? `(${match}+${misMatch}+${related}=${totalMappedControls}) ${statMappedMatches}`
-      : `(${totalMappedControls}+${noMatch}=${GenerateDelta.newControlsLength}) ${statProcessedTotal}`;
+      ? `(${match}+${misMatch}=${totalMappedControls}) ${statMappedMatches}`
+      : `(${totalMappedControls}+${related}+${noMatch}=${GenerateDelta.newControlsLength}) ${statProcessedTotal}`;
   }
 
   requiredFlagsProvided(flags: any): boolean { // skipcq: JS-0105

--- a/src/commands/generate/delta.ts
+++ b/src/commands/generate/delta.ts
@@ -773,25 +773,60 @@ export default class GenerateDelta extends BaseCommand<typeof GenerateDelta> {
    * reuse or careful authoring. Returns '' when there are no related links.
    */
   private static formatRelatedControlsReport(links: LinkRecord[]): string {
-    const related = links
-      .filter(l => l.relationship === 'related')
-      .toSorted((a, b) => b.confidence - a.confidence);
+    const related = links.filter(l => l.relationship === 'related');
     if (related.length === 0) {
       return '';
     }
-    const rows = related
-      .map((l) => {
-        const conf = `${(l.confidence * 100).toFixed(0)}%`;
-        const flag = l.potentialMismatch ? '  ** potential mismatch **' : '';
-        return `  ${basename(l.newId)}  ~ best match ${l.oldId}  [${l.matchMethod}, confidence=${conf}]${flag}`;
+    // Which new control inherited each old control's body (its primary), so
+    // each split's full shape is shown.
+    const primaryByOld = new Map<string, string>();
+    for (const l of links) {
+      if (l.relationship === 'primary' && l.oldId) {
+        primaryByOld.set(l.oldId, l.newId);
+      }
+    }
+    // Group related links by the old control they matched.
+    const groups = new Map<string, LinkRecord[]>();
+    for (const l of related) {
+      const key = l.oldId ?? '(no old match)';
+      const bucket = groups.get(key);
+      if (bucket) {
+        bucket.push(l);
+      } else {
+        groups.set(key, [l]);
+      }
+    }
+    // Order groups by their strongest related match (closest first), and the
+    // entries within each group likewise.
+    const blocks = [...groups.entries()]
+      .map(([oldId, items]) => ({
+        oldId,
+        items: items.toSorted((a, b) => b.confidence - a.confidence),
+        maxConf: Math.max(...items.map(l => l.confidence)),
+      }))
+      .toSorted((a, b) => b.maxConf - a.maxConf)
+      .map(({ oldId, items }) => {
+        const primary = primaryByOld.get(oldId);
+        const head = primary
+          ? `old control ${oldId}  (primary ${basename(primary)} kept the body):`
+          : `old control ${oldId}:`;
+        const rows = items
+          .map((l) => {
+            const conf = `${(l.confidence * 100).toFixed(0)}%`;
+            const flag = l.potentialMismatch ? '  ** potential mismatch **' : '';
+            return `    related -> ${basename(l.newId)}  [${l.matchMethod}, confidence=${conf}]${flag}`;
+          })
+          .join('\n');
+        return `${head}\n${rows}`;
       })
       .join('\n');
     return '## Related Controls (no body copied)\n'
       + 'These new controls matched an old control but were not its primary (best)\n'
       + 'match, so no control body was copied forward — they are emitted as new\n'
-      + 'controls without a body. Review the higher-confidence matches: a close one\n'
-      + 'may warrant manually reusing the old body or careful authoring.\n\n'
-      + rows
+      + 'controls without a body, grouped below by the old control they matched.\n'
+      + 'Review the higher-confidence matches: a close one may warrant manually\n'
+      + 'reusing the old body or careful authoring.\n\n'
+      + blocks
       + `\n\nTotal Related (no body copied): ${related.length}\n\n`;
   }
 

--- a/src/utils/delta_matching.ts
+++ b/src/utils/delta_matching.ts
@@ -319,23 +319,22 @@ type TierContext = {
 type ScoredCandidate = { idx: number; composite: number; cci: number };
 
 /**
- * Claim `oldId` as primary if not already claimed; otherwise mark as related.
- * Mutates `claimedOldIds` in place.
+ * Mark `oldId` as claimed so subsequently-scored new controls prefer an
+ * unclaimed old (the tier-2 spreading heuristic). This only records that
+ * *some* new control mapped here; it does NOT decide which one is primary —
+ * that is `electPrimaries`' job. Mutates `claimedOldIds` in place.
  */
-function claimOrRelate(
-  oldId: string,
-  claimedOldIds: Set<string>,
-): 'primary' | 'related' {
-  if (claimedOldIds.has(oldId)) {
-    return 'related';
-  }
+function registerClaim(oldId: string, claimedOldIds: Set<string>): void {
   claimedOldIds.add(oldId);
-  return 'primary';
 }
 
 /**
- * Construct a successful LinkRecord (any tier). Derives
- * `potentialMismatch` consistently via `computePotentialMismatch`.
+ * Construct a successful LinkRecord (any tier) as a `related` *candidate*.
+ * A tier function cannot know whether its new control is the best match for
+ * the old until the whole profile is scored, so it never assigns `primary`
+ * here; `electPrimaries` elects one primary per old control afterward and
+ * (re)computes `potentialMismatch` from the final relationship. Built as
+ * `related` with `potentialMismatch=false` (the value for any non-primary).
  */
 function makeLink(args: {
   newControl: ControlLike;
@@ -343,20 +342,15 @@ function makeLink(args: {
   matchMethod: MatchMethod;
   confidence: number;
   srg: string | null;
-  relationship: 'primary' | 'related';
 }): LinkRecord {
   return {
     oldId: args.oldId,
     newId: args.newControl.id,
     matchMethod: args.matchMethod,
     confidence: args.confidence,
-    relationship: args.relationship,
+    relationship: 'related',
     srg: args.srg,
-    potentialMismatch: computePotentialMismatch(
-      args.matchMethod,
-      args.relationship,
-      args.confidence,
-    ),
+    potentialMismatch: false,
   };
 }
 
@@ -383,13 +377,13 @@ function tier1DeterministicMatch(
   srg: string,
   claimedOldIds: Set<string>,
 ): LinkRecord {
+  registerClaim(candidate.id, claimedOldIds);
   return makeLink({
     newControl,
     oldId: candidate.id,
     matchMethod: 'srg-deterministic',
     confidence: 1,
     srg,
-    relationship: claimOrRelate(candidate.id, claimedOldIds),
   });
 }
 
@@ -452,13 +446,13 @@ function tier2CciTiebreak(
     );
   }
   const winningCandidate = candidates[winner.idx];
+  registerClaim(winningCandidate.id, ctx.claimedOldIds);
   return makeLink({
     newControl,
     oldId: winningCandidate.id,
     matchMethod: 'srg-cci-tiebreak',
     confidence: Math.max(winner.cci, 0),
     srg,
-    relationship: claimOrRelate(winningCandidate.id, ctx.claimedOldIds),
   });
 }
 
@@ -491,14 +485,99 @@ function tier3FuseFallback(
   // Invert Fuse score (0=perfect, 1=no match) into a 0-1 confidence
   // where 1.0 is perfect.
   const confidence = 1 - best.score;
+  registerClaim(best.item.originalId, ctx.claimedOldIds);
   return makeLink({
     newControl,
     oldId: best.item.originalId,
     matchMethod: 'fuse-fallback',
     confidence,
     srg,
-    relationship: claimOrRelate(best.item.originalId, ctx.claimedOldIds),
   });
+}
+
+/**
+ * Trust ordering of match tiers, used to elect a primary when several new
+ * controls (possibly from different tiers) land on one old control. Higher =
+ * more trustworthy: an SRG-deterministic match beats an SRG+CCI tiebreak,
+ * which beats a cross-SRG Fuse title fallback. `none` never reaches election.
+ */
+function matchMethodRank(matchMethod: MatchMethod): number {
+  switch (matchMethod) {
+    case 'srg-deterministic': {
+      return 3;
+    }
+    case 'srg-cci-tiebreak': {
+      return 2;
+    }
+    case 'fuse-fallback': {
+      return 1;
+    }
+    default: {
+      return 0;
+    }
+  }
+}
+
+/**
+ * Elect the `primary` link for every old control. The tier functions build
+ * each match as a `related` candidate; this is the single, authoritative
+ * place that designates primaries — there is no provisional "primary" that
+ * later gets overwritten. For each old control, the highest-confidence
+ * candidate becomes `primary` (the link that inherits the old body
+ * downstream) and the rest stay `related`; an exact tie resolves to the
+ * first candidate in new-profile input order. `potentialMismatch` is
+ * recomputed from the final relationship (it is false for `related`, so a
+ * promoted primary must be re-evaluated). Mutates and returns `links`.
+ *
+ * SCOPE: `confidence` measures each candidate's fit to the old it was
+ * *assigned* to. Tier 2's prefer-unclaimed spreading (see `tier2CciTiebreak`)
+ * can route a new control off a stronger but already-claimed old, so this
+ * elects the best body recipient *among the controls that landed on a given
+ * old* — it does not guarantee that control was on its globally-strongest
+ * old. That requires globally-optimal assignment (score all new x old pairs
+ * together), which this greedy matcher does not do; it is addressed by the
+ * requirement-text matcher rework, not here.
+ */
+export function electPrimaries(links: LinkRecord[]): LinkRecord[] {
+  const byOld = new Map<string, LinkRecord[]>();
+  for (const link of links) {
+    if (link.oldId === null || link.relationship === 'no-match') {
+      continue;
+    }
+    const bucket = byOld.get(link.oldId);
+    if (bucket) {
+      bucket.push(link);
+    } else {
+      byOld.set(link.oldId, [link]);
+    }
+  }
+  for (const group of byOld.values()) {
+    // Elect tier-first, then by confidence WITHIN a tier. Confidence is not
+    // comparable across tiers (tier 1 = 1.0; tier 2 = CCI Jaccard; tier 3 =
+    // 1 - Fuse title score), so a cross-SRG tier-3 fuzzy match must not
+    // outrank a same-SRG tier-2 match on the same old just because its raw
+    // score is higher. A higher tier (more trustworthy match) always wins;
+    // strict `>` on confidence keeps the first candidate on within-tier ties
+    // (deterministic input order).
+    let best = group[0];
+    for (const link of group) {
+      const rank = matchMethodRank(link.matchMethod);
+      const bestRank = matchMethodRank(best.matchMethod);
+      if (rank > bestRank
+        || (rank === bestRank && link.confidence > best.confidence)) {
+        best = link;
+      }
+    }
+    for (const link of group) {
+      link.relationship = link === best ? 'primary' : 'related';
+      link.potentialMismatch = computePotentialMismatch(
+        link.matchMethod,
+        link.relationship,
+        link.confidence,
+      );
+    }
+  }
+  return links;
 }
 
 /**
@@ -544,10 +623,10 @@ export function applyRequirementFirstPipeline(
       })
       : null;
 
-  // Track which old control has already been claimed as `primary`. If a
-  // second new control best-matches the same old, it becomes `related`
-  // (1:N split — multiple new controls inherit one old body, but only the
-  // highest-scoring is primary).
+  // Tracks which old controls have been mapped to, so tier 2 prefers an
+  // unclaimed old when spreading distinct new controls across olds. This is
+  // only used for candidate *selection*; `electPrimaries` (after the loop)
+  // is what designates the primary of each old control by confidence.
   const claimedOldIds = new Set<string>();
   const ctx: TierContext = { oldPrefix, newPrefix, fuse, claimedOldIds };
 
@@ -573,7 +652,7 @@ export function applyRequirementFirstPipeline(
       );
     }
   }
-  return links;
+  return electPrimaries(links);
 }
 
 /**

--- a/test/commands/generate/delta.test.ts
+++ b/test/commands/generate/delta.test.ts
@@ -2,7 +2,7 @@ import { runCommand } from '@oclif/test';
 import fs from 'fs';
 import path from 'path';
 import tmp from 'tmp';
-import { assert, describe, expect, it } from 'vitest';
+import { assert, beforeEach, describe, expect, it } from 'vitest';
 import GenerateDelta from '../../../src/commands/generate/delta';
 
 // Functional tests
@@ -161,9 +161,10 @@ const deltaCtl = (id: string, gtitle: string, cci: string[], title: string) => (
 // controlMappings so they are emitted as new controls without a body. This
 // also guarantees no two new controls share an old id in controlMappings, so
 // the mapped-control file write cannot collide.
-describe('Test generate delta mapControls 1:N body-copy policy', () => {
+describe.sequential('Test generate delta mapControls 1:N body-copy policy', () => {
+  beforeEach(resetDeltaStatics);
+
   it('maps only the primary new control to the old id; the related sibling is excluded', () => {
-    resetDeltaStatics();
     const oldProfile = { controls: [deltaCtl('SV-OLD', 'SRG-1', ['CCI-1'], 'RHEL 9 must configure the audit service.')] };
     const newProfile = { controls: [
       deltaCtl('SV-NEW-1', 'SRG-1', ['CCI-1'], 'SLES 15 must configure the audit service.'),
@@ -189,7 +190,6 @@ describe('Test generate delta mapControls 1:N body-copy policy', () => {
   });
 
   it('never maps two new controls to the same old id (collision-free controlMappings)', () => {
-    resetDeltaStatics();
     // One old control, three new controls in the same SRG block (a 3-way split).
     const oldProfile = { controls: [deltaCtl('SV-OLD', 'SRG-2', ['CCI-9'], 'RHEL 9 must restrict access.')] };
     const newProfile = { controls: [
@@ -207,7 +207,6 @@ describe('Test generate delta mapControls 1:N body-copy policy', () => {
   });
 
   it('lists every related (no-body) control in the report, highest confidence first, and never lists the primary', () => {
-    resetDeltaStatics();
     // One old, three new in the same SRG -> 1 primary + 2 related. The report
     // section must enumerate the two related controls (so reviewers can spot
     // close matches) and must not list the primary (which got the body).
@@ -239,7 +238,6 @@ describe('Test generate delta mapControls 1:N body-copy policy', () => {
   });
 
   it('produces an empty related-report section when there are no related links', () => {
-    resetDeltaStatics();
     const oldProfile = { controls: [deltaCtl('SV-OLD', 'SRG-4', ['CCI-1'], 'RHEL 9 must set a banner.')] };
     const newProfile = { controls: [deltaCtl('SV-NEW', 'SRG-4', ['CCI-1'], 'SLES 15 must set a banner.')] };
     makeDeltaCmd().mapControls(oldProfile as never, newProfile as never);
@@ -248,5 +246,64 @@ describe('Test generate delta mapControls 1:N body-copy policy', () => {
       formatRelatedControlsReport(l: typeof GenerateDelta.links): string;
     }).formatRelatedControlsReport(GenerateDelta.links);
     expect(report).toBe('');
+  });
+
+  it('gives the body to the highest-confidence sibling even when it is not the first one processed', () => {
+    // Multi-old SRG block (tier 2). SV-NEW-3 is processed LAST but is the
+    // strongest CCI match to SV-OLD-B; the prefer-unclaimed pass parks the
+    // weak SV-NEW-2 (CCI 0) on SV-OLD-B first, then SV-NEW-3 (CCI 1.0) also
+    // lands on SV-OLD-B. electPrimaries must give the body to SV-NEW-3, not
+    // the first-seen SV-NEW-2. (A by-input-order election would fail this.)
+    const oldProfile = { controls: [
+      deltaCtl('SV-OLD-A', 'SRG-X', ['CCI-1'], 'RHEL 9 must alpha.'),
+      deltaCtl('SV-OLD-B', 'SRG-X', ['CCI-2'], 'RHEL 9 must beta.'),
+    ] };
+    const newProfile = { controls: [
+      deltaCtl('SV-NEW-1', 'SRG-X', ['CCI-1'], 'SLES 15 must alpha.'),
+      deltaCtl('SV-NEW-2', 'SRG-X', ['CCI-9'], 'SLES 15 must gamma.'),
+      deltaCtl('SV-NEW-3', 'SRG-X', ['CCI-2'], 'SLES 15 must beta.'),
+    ] };
+
+    const mappings = makeDeltaCmd().mapControls(oldProfile as never, newProfile as never);
+    const byNew = Object.fromEntries(GenerateDelta.links.map(l => [l.newId, l]));
+
+    // The strongest match to SV-OLD-B is the body recipient, despite being last.
+    expect(byNew['SV-NEW-3'].relationship).toBe('primary');
+    expect(byNew['SV-NEW-3'].oldId).toBe('SV-OLD-B');
+    expect(mappings['SV-NEW-3']).toBe('SV-OLD-B');
+    // The weaker, first-seen sibling on SV-OLD-B is related and gets no body.
+    expect(byNew['SV-NEW-2'].relationship).toBe('related');
+    expect(mappings).not.toHaveProperty('SV-NEW-2');
+  });
+
+  it('counts a low-confidence elected primary as a possible mismatch (posMisMatch)', () => {
+    // tier-2 primary whose CCI Jaccard (1/3) is below TIER2_MISMATCH_THRESHOLD.
+    const oldProfile = { controls: [
+      deltaCtl('SV-OLD-A', 'SRG-Y', ['CCI-1', 'CCI-2', 'CCI-3'], 'RHEL 9 must alpha.'),
+      deltaCtl('SV-OLD-B', 'SRG-Y', ['CCI-7'], 'RHEL 9 must beta.'),
+    ] };
+    const newProfile = { controls: [
+      deltaCtl('SV-NEW', 'SRG-Y', ['CCI-1'], 'SLES 15 must alpha.'),
+    ] };
+    makeDeltaCmd().mapControls(oldProfile as never, newProfile as never);
+    const link = GenerateDelta.links.find(l => l.newId === 'SV-NEW');
+    expect(link?.relationship).toBe('primary');
+    expect(link?.potentialMismatch).toBe(true);
+    expect(GenerateDelta.posMisMatch).toBe(1);
+    expect(GenerateDelta.match).toBe(0);
+  });
+
+  it('keeps the stats invariants true under the primary-only model', () => {
+    const cmd = makeDeltaCmd() as unknown as {
+      getMappedStatisticsValidation(total: number, kind: string): string;
+    };
+    // 2 trusted primaries + 1 flagged primary = 3 mapped; 2 related; 1 no-match.
+    GenerateDelta.match = 2;
+    GenerateDelta.posMisMatch = 1;
+    GenerateDelta.dupMatch = 2;
+    GenerateDelta.noMatch = 1;
+    GenerateDelta.newControlsLength = 6;
+    expect(cmd.getMappedStatisticsValidation(3, 'totalMapped')).toContain('true');
+    expect(cmd.getMappedStatisticsValidation(3, 'totalProcessed')).toContain('true');
   });
 });

--- a/test/commands/generate/delta.test.ts
+++ b/test/commands/generate/delta.test.ts
@@ -3,6 +3,7 @@ import fs from 'fs';
 import path from 'path';
 import tmp from 'tmp';
 import { assert, describe, expect, it } from 'vitest';
+import GenerateDelta from '../../../src/commands/generate/delta';
 
 // Functional tests
 describe.sequential('Test generate delta command', () => {
@@ -132,5 +133,117 @@ describe.sequential('Test generate delta command', () => {
     expect(stdout).to.include('Best Match Candidate:  V-93205 --> SV-254240');
     expect(stdout).to.include('Best Match Candidate:  V-93207 --> SV-254241');
     expect(stdout).to.include('Best Match Candidate:  V-93461 --> SV-254242');
+  });
+});
+
+// GenerateDelta extends an oclif Command; instantiate it directly to unit
+// test mapControls without a full command run. The minimal config stub is
+// enough — mapControls only touches the instance logger and static counters.
+const makeDeltaCmd = () => new (GenerateDelta as unknown as new (argv: string[], config: unknown) => {
+  mapControls(o: unknown, n: unknown): Record<string, string>;
+})([], { runHook: () => Promise.resolve({}) });
+
+const resetDeltaStatics = () => {
+  GenerateDelta.match = 0;
+  GenerateDelta.posMisMatch = 0;
+  GenerateDelta.dupMatch = 0;
+  GenerateDelta.noMatch = 0;
+  GenerateDelta.links = [];
+};
+
+const deltaCtl = (id: string, gtitle: string, cci: string[], title: string) => ({
+  id, title, tags: { gtitle, cci }, code: `control '${id}' do\nend`,
+});
+
+// Unit tests for the 1:N split body-copy policy in mapControls. When several
+// new controls resolve to one old control, ONLY the primary (best match)
+// inherits the old Ruby body; `related` links are deliberately left out of
+// controlMappings so they are emitted as new controls without a body. This
+// also guarantees no two new controls share an old id in controlMappings, so
+// the mapped-control file write cannot collide.
+describe('Test generate delta mapControls 1:N body-copy policy', () => {
+  it('maps only the primary new control to the old id; the related sibling is excluded', () => {
+    resetDeltaStatics();
+    const oldProfile = { controls: [deltaCtl('SV-OLD', 'SRG-1', ['CCI-1'], 'RHEL 9 must configure the audit service.')] };
+    const newProfile = { controls: [
+      deltaCtl('SV-NEW-1', 'SRG-1', ['CCI-1'], 'SLES 15 must configure the audit service.'),
+      deltaCtl('SV-NEW-2', 'SRG-1', ['CCI-1'], 'SLES 15 must configure the audit service thresholds.'),
+    ] };
+
+    const mappings = makeDeltaCmd().mapControls(oldProfile as never, newProfile as never);
+
+    // Both new controls link to the one old; exactly one is primary.
+    const byNew = Object.fromEntries(GenerateDelta.links.map(l => [l.newId, l]));
+    expect(byNew['SV-NEW-1'].relationship).toBe('primary');
+    expect(byNew['SV-NEW-2'].relationship).toBe('related');
+    expect(byNew['SV-NEW-1'].oldId).toBe('SV-OLD');
+    expect(byNew['SV-NEW-2'].oldId).toBe('SV-OLD');
+
+    // ...but only the primary gets a controlMappings entry (and thus a body).
+    expect(mappings).toEqual({ 'SV-NEW-1': 'SV-OLD' });
+    expect(mappings).not.toHaveProperty('SV-NEW-2');
+
+    // Stats: 1 mapped primary, 1 related (no body), invariant holds.
+    expect(GenerateDelta.match).toBe(1);
+    expect(GenerateDelta.dupMatch).toBe(1);
+  });
+
+  it('never maps two new controls to the same old id (collision-free controlMappings)', () => {
+    resetDeltaStatics();
+    // One old control, three new controls in the same SRG block (a 3-way split).
+    const oldProfile = { controls: [deltaCtl('SV-OLD', 'SRG-2', ['CCI-9'], 'RHEL 9 must restrict access.')] };
+    const newProfile = { controls: [
+      deltaCtl('SV-A', 'SRG-2', ['CCI-9'], 'SLES 15 must restrict access.'),
+      deltaCtl('SV-B', 'SRG-2', ['CCI-9'], 'SLES 15 must restrict access to logs.'),
+      deltaCtl('SV-C', 'SRG-2', ['CCI-9'], 'SLES 15 must restrict access to keys.'),
+    ] };
+
+    const mappings = makeDeltaCmd().mapControls(oldProfile as never, newProfile as never);
+
+    // At most one new control maps to any given old id -> no file-write collision.
+    const oldIds = Object.values(mappings);
+    expect(new Set(oldIds).size).toBe(oldIds.length);
+    expect(oldIds.filter(o => o === 'SV-OLD')).toHaveLength(1);
+  });
+
+  it('lists every related (no-body) control in the report, highest confidence first, and never lists the primary', () => {
+    resetDeltaStatics();
+    // One old, three new in the same SRG -> 1 primary + 2 related. The report
+    // section must enumerate the two related controls (so reviewers can spot
+    // close matches) and must not list the primary (which got the body).
+    const oldProfile = { controls: [deltaCtl('SV-OLD', 'SRG-3', ['CCI-1'], 'RHEL 9 must enable auditing.')] };
+    const newProfile = { controls: [
+      deltaCtl('SV-NEW-1', 'SRG-3', ['CCI-1'], 'SLES 15 must enable auditing.'),
+      deltaCtl('SV-NEW-2', 'SRG-3', ['CCI-1'], 'SLES 15 must enable auditing for logins.'),
+      deltaCtl('SV-NEW-3', 'SRG-3', ['CCI-1'], 'SLES 15 must enable auditing for sudo.'),
+    ] };
+    makeDeltaCmd().mapControls(oldProfile as never, newProfile as never);
+
+    const report = (GenerateDelta as unknown as {
+      formatRelatedControlsReport(l: typeof GenerateDelta.links): string;
+    }).formatRelatedControlsReport(GenerateDelta.links);
+
+    const primary = GenerateDelta.links.find(l => l.relationship === 'primary')!;
+    const related = GenerateDelta.links.filter(l => l.relationship === 'related');
+    expect(related.length).toBe(2);
+    expect(report).toContain('Related Controls (no body copied)');
+    for (const r of related) {
+      expect(report).toContain(r.newId);
+    }
+    // The primary keeps the body and must not appear in the related list.
+    expect(report).not.toContain(`${primary.newId}  ~ best match`);
+    expect(report).toContain(`Total Related (no body copied): ${related.length}`);
+  });
+
+  it('produces an empty related-report section when there are no related links', () => {
+    resetDeltaStatics();
+    const oldProfile = { controls: [deltaCtl('SV-OLD', 'SRG-4', ['CCI-1'], 'RHEL 9 must set a banner.')] };
+    const newProfile = { controls: [deltaCtl('SV-NEW', 'SRG-4', ['CCI-1'], 'SLES 15 must set a banner.')] };
+    makeDeltaCmd().mapControls(oldProfile as never, newProfile as never);
+
+    const report = (GenerateDelta as unknown as {
+      formatRelatedControlsReport(l: typeof GenerateDelta.links): string;
+    }).formatRelatedControlsReport(GenerateDelta.links);
+    expect(report).toBe('');
   });
 });

--- a/test/commands/generate/delta.test.ts
+++ b/test/commands/generate/delta.test.ts
@@ -227,11 +227,14 @@ describe('Test generate delta mapControls 1:N body-copy policy', () => {
     const related = GenerateDelta.links.filter(l => l.relationship === 'related');
     expect(related.length).toBe(2);
     expect(report).toContain('Related Controls (no body copied)');
+    // Grouped by the old control, which names the primary that kept the body.
+    expect(report).toContain(`old control ${primary.oldId}  (primary ${primary.newId} kept the body):`);
+    // Each related new control is listed under its old group, labeled `related ->`.
     for (const r of related) {
-      expect(report).toContain(r.newId);
+      expect(report).toContain(`related -> ${r.newId}`);
     }
-    // The primary keeps the body and must not appear in the related list.
-    expect(report).not.toContain(`${primary.newId}  ~ best match`);
+    // The primary kept the body, so it must not be listed as a related entry.
+    expect(report).not.toContain(`related -> ${primary.newId}`);
     expect(report).toContain(`Total Related (no body copied): ${related.length}`);
   });
 

--- a/test/utils/__tests__/delta_matching.test.ts
+++ b/test/utils/__tests__/delta_matching.test.ts
@@ -7,12 +7,91 @@ import {
   cciJaccard,
   extractCcis,
   extractSrgId,
+  electPrimaries,
   normalizeTitle,
   TIER2_COMPOSITE_CCI_WEIGHT,
   TIER2_COMPOSITE_TITLE_WEIGHT,
   tokenJaccard,
   type LinkRecord,
 } from '../../../src/utils/delta_matching';
+
+// Minimal LinkRecord builder for electPrimaries tests.
+const mkLink = (
+  newId: string,
+  oldId: string | null,
+  relationship: LinkRecord['relationship'],
+  confidence: number,
+  matchMethod: LinkRecord['matchMethod'] = relationship === 'no-match' ? 'none' : 'srg-cci-tiebreak',
+): LinkRecord => ({
+  oldId,
+  newId,
+  matchMethod,
+  confidence,
+  relationship,
+  potentialMismatch: false,
+});
+
+describe('electPrimaries', () => {
+  it('elects the highest-confidence candidate of an old control as primary', () => {
+    // All candidates land on SV-OLD; the best fit (0.91) must take the body.
+    const links = [
+      mkLink('SV-A', 'SV-OLD', 'related', 0.14),
+      mkLink('SV-B', 'SV-OLD', 'related', 0.89),
+      mkLink('SV-C', 'SV-OLD', 'related', 0.91),
+    ];
+    electPrimaries(links);
+    const byNew = Object.fromEntries(links.map(l => [l.newId, l.relationship]));
+    expect(byNew['SV-C']).toBe('primary');
+    expect(byNew['SV-A']).toBe('related');
+    expect(byNew['SV-B']).toBe('related');
+    // Exactly one primary per old control.
+    expect(links.filter(l => l.relationship === 'primary')).toHaveLength(1);
+  });
+
+  it('resolves an exact confidence tie to the first candidate in input order', () => {
+    const links = [
+      mkLink('SV-A', 'SV-OLD', 'related', 1),
+      mkLink('SV-B', 'SV-OLD', 'related', 1),
+    ];
+    electPrimaries(links);
+    expect(links.find(l => l.newId === 'SV-A')?.relationship).toBe('primary');
+    expect(links.find(l => l.newId === 'SV-B')?.relationship).toBe('related');
+  });
+
+  it('elects the sole candidate of a 1:1 mapping and leaves no-match untouched', () => {
+    const links = [
+      mkLink('SV-A', 'SV-OLD-1', 'related', 0.6),
+      mkLink('SV-B', null, 'no-match', 0),
+    ];
+    electPrimaries(links);
+    expect(links[0].relationship).toBe('primary');
+    expect(links[1].relationship).toBe('no-match');
+  });
+
+  it('elects tier-first: a same-SRG tier-2 match beats a higher-confidence cross-SRG fuse match on the same old', () => {
+    // Confidence is not comparable across tiers (tier 2 = CCI Jaccard, tier 3
+    // = 1 - Fuse score). A cross-SRG fuzzy match at 0.80 must NOT outrank a
+    // same-SRG CCI match at 0.50 for the same old control.
+    const links = [
+      mkLink('SV-FUSE', 'SV-OLD', 'related', 0.8, 'fuse-fallback'),
+      mkLink('SV-CCI', 'SV-OLD', 'related', 0.5, 'srg-cci-tiebreak'),
+    ];
+    electPrimaries(links);
+    expect(links.find(l => l.newId === 'SV-CCI')?.relationship).toBe('primary');
+    expect(links.find(l => l.newId === 'SV-FUSE')?.relationship).toBe('related');
+  });
+
+  it('recomputes potentialMismatch from the elected relationship', () => {
+    // A low-confidence candidate (0.1) carries potentialMismatch=false while
+    // `related`; once elected primary it must be re-evaluated to true
+    // (srg-cci-tiebreak, confidence < TIER2_MISMATCH_THRESHOLD=0.5).
+    const links = [mkLink('SV-A', 'SV-OLD', 'related', 0.1)];
+    expect(links[0].potentialMismatch).toBe(false);
+    electPrimaries(links);
+    expect(links[0].relationship).toBe('primary');
+    expect(links[0].potentialMismatch).toBe(true);
+  });
+});
 
 // Minimal Control-shaped test fixtures. The real inspec-objects Control has
 // many more fields; these tests exercise only the fields our matcher reads.


### PR DESCRIPTION
Resolves #8488. In short -- in cases where an 'old' control in a source profile had several reasonable matches in the 'new' baseline, SAF CLI would pick _whichever the last reasonable match it saw_ to copy the InSpec body to, instead of the _best_ match (which we were already calculating, and referring to as the primary match).

This PR a) makes SAF CLI *only* map an old control's InSpec body to its *primary* match in the output, and b) adds a report section to the delta artifacts that specifically calls out old controls with extra 'related' matches for further review after delta run. Delta now says "we copied the code block into the best candidate, but this other set of candidates was close enough that you should probably check."

Tried to match existing report style for the new related-controls report section. Looks like this:

```
old control SV-257826  (primary SV-234804 kept the body):
    related -> SV-234818  [srg-deterministic, confidence=100%]
old control SV-257918  (primary SV-234842 kept the body):
    related -> SV-234843  [srg-cci-tiebreak, confidence=100%]
    related -> SV-234845  [srg-cci-tiebreak, confidence=100%]
old control SV-257919  (primary SV-234841 kept the body):
    related -> SV-234844  [srg-cci-tiebreak, confidence=100%]
old control SV-258133  (primary SV-234857 kept the body):
    related -> SV-234858  [srg-deterministic, confidence=100%]
old control SV-258071  (primary SV-234982 kept the body):
    related -> SV-234983  [srg-deterministic, confidence=100%]
old control SV-257929  (primary SV-234828 kept the body):
    related -> SV-255921  [srg-deterministic, confidence=100%]
old control SV-257842  (primary SV-255922 kept the body):
    related -> SV-256983  [srg-cci-tiebreak, confidence=100%]
old control SV-258012  (primary SV-234806 kept the body):
    related -> SV-234809  [fuse-fallback, confidence=90%]
    related -> SV-234808  [fuse-fallback, confidence=90%]
old control SV-258217  (primary SV-234902 kept the body):
    related -> SV-234975  [fuse-fallback, confidence=77%]
old control SV-258137  (primary SV-234961 kept the body):
    related -> SV-234962  [fuse-fallback, confidence=75%]
old control SV-258149  (primary SV-234865 kept the body):
    related -> SV-234979  [srg-cci-tiebreak, confidence=50%]

Total Related (no body copied): 13
```

Since this one is a bugfix and I had a discussion with @aaronlippold to validate that we do in fact only want to copy code to the primary match, I didn't ADR this one before putting up the full PR with code changes.